### PR TITLE
Remove warning about missing access token on Android

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/MapBoxUtils.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapBoxUtils.java
@@ -23,15 +23,13 @@ abstract class MapBoxUtils {
                     .getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
             Bundle bundle = ai.metaData;
             String token = bundle.getString("com.mapbox.token");
-            if (token == null || token.isEmpty()) {
-                throw new NullPointerException();
+            if (token == null ) {
+                token = "";
             }
             return token;
-        } catch (Exception e) {
-            Log.e(TAG, "Failed to find an Access Token in the Application meta-data. Maps may not load correctly. " +
-                    "Please refer to the installation guide at https://github.com/tobrun/flutter-mapbox-gl#mapbox-access-token " +
-                    "for troubleshooting advice." + e.getMessage());
+        } catch (PackageManager.NameNotFoundException e) {
+            return "";
         }
-        return null;
+
     }
 }


### PR DESCRIPTION
Fixes #20 

Note: When setting the token to null and not specifying a style, this will currently crash the app on Android.

We need to also update to a newer version of the Maplibre GL native libraries, where this is resolved.