### PR TITLE
Example: use maplibre styles and add new demo style

### DIFF
--- a/example/assets/style.json
+++ b/example/assets/style.json
@@ -1,35 +1,36 @@
 {
 	"version": 8,
-	"name": "Example taken from https://docs.mapbox.com/ios/maps/examples/source-custom-vector/",
+	"name": "Demo style",
+	"center": [
+		50,
+		10
+	],
+	"zoom": 4,
 	"sources": {
-		"mapillary": {
+		"demotiles": {
 			"type": "vector",
-			"tiles": [
-				"https://d25uarhxywzl1j.cloudfront.net/v0.1/{z}/{x}/{y}.mvt"
-			],
-			"attribution": "<a href=\"https://www.mapillary.com\" target=\"_blank\">© Mapillary, CC BY</a>",
-			"maxzoom": 14
+			"url": "https://demotiles.maplibre.org/tiles/tiles.json"
 		}
 	},
-	"layers": [{
+	"sprite": "",
+	"glyphs": "https://orangemug.github.io/font-glyphs/glyphs/{fontstack}/{range}.pbf",
+	"layers": [
+		{
 			"id": "background",
 			"type": "background",
 			"paint": {
-				"background-color": "#485E77"
+				"background-color": "rgba(255, 255, 255, 1)"
 			}
 		},
 		{
-			"id": "mapillary-sequences",
+			"id": "countries",
 			"type": "line",
-			"source": "mapillary",
-			"source-layer": "mapillary-sequences",
-			"filter": [
-				"==",
-				"$type",
-				"LineString"
-			],
+			"source": "demotiles",
+			"source-layer": "countries",
 			"paint": {
-				"line-color": "#F56745"
+				"line-color": "rgba(0, 0, 0, 1)",
+				"line-width": 1,
+				"line-opacity": 1
 			}
 		}
 	]

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -63,7 +63,6 @@ class MapsDemo extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('MapboxMaps examples')),
       appBar: AppBar(title: const Text('Maplibre examples')),
       body: ListView.builder(
         itemCount: _allPages.length,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -64,6 +64,7 @@ class MapsDemo extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('MapboxMaps examples')),
+      appBar: AppBar(title: const Text('Maplibre examples')),
       body: ListView.builder(
         itemCount: _allPages.length,
         itemBuilder: (_, int index) => ListTile(

--- a/example/lib/map_ui.dart
+++ b/example/lib/map_ui.dart
@@ -50,14 +50,11 @@ class MapUiBodyState extends State<MapUiBody> {
   // Style string can a reference to a local or remote resources.
   // On Android the raw JSON can also be passed via a styleString, on iOS this is not supported.
   List<String> _styleStrings = [
-    MapboxStyles.MAPBOX_STREETS,
-    MapboxStyles.SATELLITE,
+    "https://demotiles.maplibre.org/style.json",
     "assets/style.json"
   ];
   List<String> _styleStringLabels = [
-    "MAPBOX_STREETS",
-    "SATELLITE",
-    "LOCAL_ASSET"
+    "Maplibre demo style", "Local style file"
   ];
   bool _rotateGesturesEnabled = true;
   bool _scrollGesturesEnabled = true;


### PR DESCRIPTION
Fixes #18 

In the "User Interface" page, switch to Maplibre demo styles. Including a new, very simple style stored as local asset.