### PR TITLE
Remove access token, update libraries, replace example styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ Map styles can be supplied by setting the `styleString` in the `MapOptions`. The
 3. Passing the style as a local file. create an JSON file in app directory (e.g. ApplicationDocumentsDirectory). Set the style string to the absolute path of this JSON file.
 4. Passing the raw JSON of the map style. This is only supported on Android.  
 
+### Tile sources requiring an API key
+If your tile source requires an API key, we recomend directly specifying a source url with the API key included.
+For example:
+
+ `https://tiles.example.com/{z}/{x}/{y}.vector.pbf?api_key={your_key}`
+
 
 
 ## Location features

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     dependencies {
-        implementation 'org.maplibre.gl:android-sdk:9.4.2'
+        implementation 'org.maplibre.gl:android-sdk:9.5.1'
         implementation 'org.maplibre.gl:android-plugin-annotation-v9:1.0.0'
         implementation 'org.maplibre.gl:android-plugin-localization-v9:1.0.0'
         implementation 'org.maplibre.gl:android-plugin-offline-v9:1.0.0'

--- a/android/src/main/java/com/mapbox/mapboxgl/GlobalMethodHandler.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/GlobalMethodHandler.java
@@ -55,8 +55,7 @@ class GlobalMethodHandler implements MethodChannel.MethodCallHandler {
 
     @Override
     public void onMethodCall(MethodCall methodCall, MethodChannel.Result result) {
-        String accessToken = methodCall.argument("accessToken");
-        MapBoxUtils.getMapbox(context, accessToken);
+        MapBoxUtils.getMapbox(context);
 
         switch (methodCall.method) {
             case "installOfflineMapTiles":

--- a/android/src/main/java/com/mapbox/mapboxgl/MapBoxUtils.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapBoxUtils.java
@@ -13,23 +13,7 @@ import com.mapbox.mapboxsdk.Mapbox;
 abstract class MapBoxUtils {
     private static final String TAG = "MapboxMapController";
 
-    static Mapbox getMapbox(Context context, String accessToken) {
-        return Mapbox.getInstance(context, accessToken == null ? getAccessToken(context) : accessToken);
-    }
-
-    private static String getAccessToken(@NonNull Context context) {
-        try {
-            ApplicationInfo ai = context.getPackageManager()
-                    .getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
-            Bundle bundle = ai.metaData;
-            String token = bundle.getString("com.mapbox.token");
-            if (token == null ) {
-                token = "";
-            }
-            return token;
-        } catch (PackageManager.NameNotFoundException e) {
-            return "";
-        }
-
+    static Mapbox getMapbox(Context context) {
+        return Mapbox.getInstance(context);
     }
 }

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
@@ -30,15 +30,15 @@ class MapboxMapBuilder implements MapboxMapOptionsSink {
   private boolean myLocationEnabled = false;
   private int myLocationTrackingMode = 0;
   private int myLocationRenderMode = 0;
-  private String styleString = Style.MAPBOX_STREETS;
+  private String styleString = "https://demotiles.maplibre.org/style.json";
   private List<String> annotationOrder = new ArrayList();
   private List<String> annotationConsumeTapEvents = new ArrayList();
 
 
   MapboxMapController build(
-    int id, Context context, BinaryMessenger messenger, MapboxMapsPlugin.LifecycleProvider lifecycleProvider, String accessToken) {
+    int id, Context context, BinaryMessenger messenger, MapboxMapsPlugin.LifecycleProvider lifecycleProvider) {
     final MapboxMapController controller =
-      new MapboxMapController(id, context,  messenger, lifecycleProvider, options, accessToken, styleString, annotationOrder, annotationConsumeTapEvents);
+      new MapboxMapController(id, context,  messenger, lifecycleProvider, options, styleString, annotationOrder, annotationConsumeTapEvents);
     controller.init();
     controller.setMyLocationEnabled(myLocationEnabled);
     controller.setMyLocationTrackingMode(myLocationTrackingMode);

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -141,11 +141,10 @@ final class MapboxMapController
     BinaryMessenger messenger,
     MapboxMapsPlugin.LifecycleProvider lifecycleProvider,
     MapboxMapOptions options,
-    String accessToken,
     String styleStringInitial,
     List<String> annotationOrder,
     List<String> annotationConsumeTapEvents) {
-    MapBoxUtils.getMapbox(context, accessToken);
+    MapBoxUtils.getMapbox(context);
     this.id = id;
     this.context = context;
     this.styleStringInitial = styleStringInitial;

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapFactory.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapFactory.java
@@ -43,6 +43,6 @@ public class MapboxMapFactory extends PlatformViewFactory {
       List<String> annotations = Convert.toAnnotationConsumeTapEvents(params.get("annotationConsumeTapEvents"));
       builder.setAnnotationConsumeTapEvents(annotations);
     }
-    return builder.build(id, context, messenger, lifecycleProvider, (String) params.get("accessToken"));
+    return builder.build(id, context, messenger, lifecycleProvider);
   }
 }

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -43,8 +43,6 @@
 	<false/>
 	<key>io.flutter.embedded_views_preview</key>
 	<true/>
-    <key>MGLMapboxAccessToken</key>
-    <string>YOUR_KEY_HERE</string>
 	<key>MGLMapboxMetricsEnabledSettingShownInApp</key>
 	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>

--- a/example/lib/animate_camera.dart
+++ b/example/lib/animate_camera.dart
@@ -5,7 +5,6 @@
 import 'package:flutter/material.dart';
 import 'package:maplibre_gl/mapbox_gl.dart';
 
-import 'main.dart';
 import 'page.dart';
 
 class AnimateCameraPage extends ExamplePage {
@@ -42,7 +41,6 @@ class AnimateCameraState extends State<AnimateCamera> {
             width: 300.0,
             height: 200.0,
             child: MaplibreMap(
-              accessToken: MapsDemo.ACCESS_TOKEN,
               onMapCreated: _onMapCreated,
               initialCameraPosition:
                   const CameraPosition(target: LatLng(0.0, 0.0)),

--- a/example/lib/annotation_order_maps.dart
+++ b/example/lib/annotation_order_maps.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:maplibre_gl/mapbox_gl.dart';
 
-import 'main.dart';
 import 'page.dart';
 
 class AnnotationOrderPage extends ExamplePage {
@@ -45,7 +44,7 @@ class _AnnotationOrderBodyState extends State<AnnotationOrderBody> {
                     width: 250.0,
                     height: 250.0,
                     child: MaplibreMap(
-                      accessToken: MapsDemo.ACCESS_TOKEN,
+                      
                       onMapCreated: onMapCreatedOne,
                       onStyleLoadedCallback: () => onStyleLoaded(controllerOne),
                       initialCameraPosition: CameraPosition(
@@ -80,7 +79,7 @@ class _AnnotationOrderBodyState extends State<AnnotationOrderBody> {
                     width: 250.0,
                     height: 250.0,
                     child: MaplibreMap(
-                      accessToken: MapsDemo.ACCESS_TOKEN,
+                      
                       onMapCreated: onMapCreatedTwo,
                       onStyleLoadedCallback: () => onStyleLoaded(controllerTwo),
                       initialCameraPosition: CameraPosition(

--- a/example/lib/custom_marker.dart
+++ b/example/lib/custom_marker.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:maplibre_gl/mapbox_gl.dart';
 
-import 'main.dart';
 import 'page.dart';
 
 const randomMarkerNum = 100;
@@ -85,7 +84,6 @@ class CustomMarkerState extends State<CustomMarker> {
       body: Stack(
           children: [
             MaplibreMap(
-              accessToken: MapsDemo.ACCESS_TOKEN,
               trackCameraPosition: true,
               onMapCreated: _onMapCreated,
               onMapLongClick: _onMapLongClickCallback,

--- a/example/lib/full_map.dart
+++ b/example/lib/full_map.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:maplibre_gl/mapbox_gl.dart';
 
-import 'main.dart';
 import 'page.dart';
 
 class FullMapPage extends ExamplePage {
@@ -31,7 +30,6 @@ class FullMapState extends State<FullMap> {
   Widget build(BuildContext context) {
     return new Scaffold(
         body: MaplibreMap(
-      accessToken: MapsDemo.ACCESS_TOKEN,
       onMapCreated: _onMapCreated,
       initialCameraPosition: const CameraPosition(target: LatLng(0.0, 0.0)),
       onStyleLoadedCallback: onStyleLoadedCallback,

--- a/example/lib/line.dart
+++ b/example/lib/line.dart
@@ -7,7 +7,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:maplibre_gl/mapbox_gl.dart';
 
-import 'main.dart';
 import 'page.dart';
 
 class LinePage extends ExamplePage {
@@ -140,7 +139,6 @@ class LineBodyState extends State<LineBody> {
             width: 300.0,
             height: 200.0,
             child: MaplibreMap(
-              accessToken: MapsDemo.ACCESS_TOKEN,
               onMapCreated: _onMapCreated,
               onStyleLoadedCallback: onStyleLoadedCallback,
               initialCameraPosition: const CameraPosition(

--- a/example/lib/local_style.dart
+++ b/example/lib/local_style.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:maplibre_gl/mapbox_gl.dart';
 import 'package:path_provider/path_provider.dart';
 
-import 'main.dart';
 import 'page.dart';
 
 class LocalStylePage extends ExamplePage {
@@ -64,7 +63,6 @@ class LocalStyleState extends State<LocalStyle> {
 
     return new Scaffold(
       body: MaplibreMap(
-        accessToken: MapsDemo.ACCESS_TOKEN,
         styleString: styleAbsoluteFilePath,
         onMapCreated: _onMapCreated,
         initialCameraPosition: const CameraPosition(target: LatLng(0.0, 0.0)),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -42,8 +42,6 @@ final List<ExamplePage> _allPages = <ExamplePage>[
 ];
 
 class MapsDemo extends StatelessWidget {
-  //FIXME: Add your Mapbox access token here
-  static const String ACCESS_TOKEN = "YOUR_TOKEN_HERE";
 
   void _pushPage(BuildContext context, ExamplePage page) async {
     if (!kIsWeb) {

--- a/example/lib/map_ui.dart
+++ b/example/lib/map_ui.dart
@@ -8,7 +8,6 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:maplibre_gl/mapbox_gl.dart';
 
-import 'main.dart';
 import 'page.dart';
 
 final LatLngBounds sydneyBounds = LatLngBounds(
@@ -290,7 +289,6 @@ class MapUiBodyState extends State<MapUiBody> {
   @override
   Widget build(BuildContext context) {
     final MaplibreMap mapboxMap = MaplibreMap(
-      accessToken: MapsDemo.ACCESS_TOKEN,
       onMapCreated: onMapCreated,
       initialCameraPosition: _kInitialPosition,
       trackCameraPosition: true,

--- a/example/lib/move_camera.dart
+++ b/example/lib/move_camera.dart
@@ -5,7 +5,6 @@
 import 'package:flutter/material.dart';
 import 'package:maplibre_gl/mapbox_gl.dart';
 
-import 'main.dart';
 import 'page.dart';
 
 class MoveCameraPage extends ExamplePage {
@@ -41,7 +40,6 @@ class MoveCameraState extends State<MoveCamera> {
             width: 300.0,
             height: 200.0,
             child: MaplibreMap(
-              accessToken: MapsDemo.ACCESS_TOKEN,
               onMapCreated: _onMapCreated,
               onCameraIdle: () => print("onCameraIdle"),
               initialCameraPosition:

--- a/example/lib/offline_regions.dart
+++ b/example/lib/offline_regions.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:maplibre_gl/mapbox_gl.dart';
-import 'package:maplibre_gl_example/main.dart';
 
 import 'offline_region_map.dart';
 import 'page.dart';
@@ -25,19 +24,19 @@ final List<OfflineRegionDefinition> regionDefinitions = [
     bounds: hawaiiBounds,
     minZoom: 3.0,
     maxZoom: 8.0,
-    mapStyleUrl: MapboxStyles.MAPBOX_STREETS,
+    mapStyleUrl: "https://demotiles.maplibre.org/style.json",
   ),
   OfflineRegionDefinition(
     bounds: santiagoBounds,
     minZoom: 10.0,
     maxZoom: 16.0,
-    mapStyleUrl: MapboxStyles.MAPBOX_STREETS,
+    mapStyleUrl: "https://demotiles.maplibre.org/style.json",
   ),
   OfflineRegionDefinition(
     bounds: aucklandBounds,
     minZoom: 13.0,
     maxZoom: 16.0,
-    mapStyleUrl: MapboxStyles.MAPBOX_STREETS,
+    mapStyleUrl: "https://demotiles.maplibre.org/style.json",
   ),
 ];
 
@@ -181,7 +180,7 @@ class _OfflineRegionsBodyState extends State<OfflineRegionBody> {
 
   void _updateListOfRegions() async {
     List<OfflineRegion> offlineRegions =
-        await getListOfRegions(accessToken: MapsDemo.ACCESS_TOKEN);
+        await getListOfRegions();
     List<OfflineRegionListItem> regionItems = [];
     for (var item in allRegions) {
       final offlineRegion = offlineRegions.firstWhere(
@@ -211,7 +210,6 @@ class _OfflineRegionsBodyState extends State<OfflineRegionBody> {
         metadata: {
           'name': regionNames[index],
         },
-        accessToken: MapsDemo.ACCESS_TOKEN,
       );
       setState(() {
         _items.removeAt(index);
@@ -244,7 +242,6 @@ class _OfflineRegionsBodyState extends State<OfflineRegionBody> {
 
     await deleteOfflineRegion(
       item.downloadedId,
-      accessToken: MapsDemo.ACCESS_TOKEN,
     );
 
     setState(() {

--- a/example/lib/place_batch.dart
+++ b/example/lib/place_batch.dart
@@ -4,7 +4,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:maplibre_gl/mapbox_gl.dart';
-import 'package:maplibre_gl_example/main.dart';
 
 import 'page.dart';
 
@@ -146,7 +145,6 @@ class BatchAddBodyState extends State<BatchAddBody> {
           child: SizedBox(
             height: 200.0,
             child: MaplibreMap(
-              accessToken: MapsDemo.ACCESS_TOKEN,
               onMapCreated: _onMapCreated,
               initialCameraPosition: const CameraPosition(
                 target: LatLng(-33.8, 151.511),

--- a/example/lib/place_circle.dart
+++ b/example/lib/place_circle.dart
@@ -8,7 +8,6 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:maplibre_gl/mapbox_gl.dart';
 
-import 'main.dart';
 import 'page.dart';
 
 class PlaceCirclePage extends ExamplePage {
@@ -219,7 +218,6 @@ class PlaceCircleBodyState extends State<PlaceCircleBody> {
             width: 300.0,
             height: 200.0,
             child: MaplibreMap(
-              accessToken: MapsDemo.ACCESS_TOKEN,
               onMapCreated: _onMapCreated,
               initialCameraPosition: const CameraPosition(
                 target: LatLng(-33.852, 151.211),

--- a/example/lib/place_fill.dart
+++ b/example/lib/place_fill.dart
@@ -9,7 +9,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:maplibre_gl/mapbox_gl.dart';
 
-import 'main.dart';
 import 'page.dart';
 
 class PlaceFillPage extends ExamplePage {
@@ -171,7 +170,6 @@ class PlaceFillBodyState extends State<PlaceFillBody> {
             width: 300.0,
             height: 200.0,
             child: MaplibreMap(
-              accessToken: MapsDemo.ACCESS_TOKEN,
               onMapCreated: _onMapCreated,
               onStyleLoadedCallback: _onStyleLoaded,
               initialCameraPosition: const CameraPosition(

--- a/example/lib/place_source.dart
+++ b/example/lib/place_source.dart
@@ -9,7 +9,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:maplibre_gl/mapbox_gl.dart';
 
-import 'main.dart';
 import 'page.dart';
 
 class PlaceSourcePage extends ExamplePage {

--- a/example/lib/place_source.dart
+++ b/example/lib/place_source.dart
@@ -91,7 +91,6 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
             width: 300.0,
             height: 200.0,
             child: MaplibreMap(
-              accessToken: MapsDemo.ACCESS_TOKEN,
               onMapCreated: _onMapCreated,
               initialCameraPosition: const CameraPosition(
                 target: LatLng(-33.852, 151.211),

--- a/example/lib/place_symbol.dart
+++ b/example/lib/place_symbol.dart
@@ -12,7 +12,6 @@ import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 import 'package:maplibre_gl/mapbox_gl.dart';
 
-import 'main.dart';
 import 'page.dart';
 
 class PlaceSymbolPage extends ExamplePage {
@@ -286,7 +285,6 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
             width: 300.0,
             height: 200.0,
             child: MaplibreMap(
-              accessToken: MapsDemo.ACCESS_TOKEN,
               onMapCreated: _onMapCreated,
               onStyleLoadedCallback: _onStyleLoaded,
               initialCameraPosition: const CameraPosition(

--- a/example/lib/scrolling_map.dart
+++ b/example/lib/scrolling_map.dart
@@ -8,7 +8,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:maplibre_gl/mapbox_gl.dart';
 
-import 'main.dart';
 import 'page.dart';
 
 class ScrollingMapPage extends ExamplePage {
@@ -51,8 +50,7 @@ class _ScrollingMapBodyState extends State<ScrollingMapBody> {
                     width: 300.0,
                     height: 300.0,
                     child: MaplibreMap(
-                      accessToken: MapsDemo.ACCESS_TOKEN,
-                      onMapCreated: onMapCreatedOne,
+                     onMapCreated: onMapCreatedOne,
                       onStyleLoadedCallback: () => onStyleLoaded(controllerOne),
                       initialCameraPosition: CameraPosition(
                         target: center,
@@ -87,8 +85,7 @@ class _ScrollingMapBodyState extends State<ScrollingMapBody> {
                     width: 300.0,
                     height: 300.0,
                     child: MaplibreMap(
-                      accessToken: MapsDemo.ACCESS_TOKEN,
-                      onMapCreated: onMapCreatedTwo,
+                     onMapCreated: onMapCreatedTwo,
                       onStyleLoadedCallback: () => onStyleLoaded(controllerTwo),
                       initialCameraPosition: CameraPosition(
                         target: center,

--- a/ios/maplibre_gl.podspec
+++ b/ios/maplibre_gl.podspec
@@ -16,7 +16,7 @@ A new Flutter plugin.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'MapLibreAnnotationExtension', '~> 0.0.1-beta.2'
-  s.dependency 'MapLibre', '~> 5.12.0'
+  s.dependency 'MapLibre', '~> 5.12.1'
   s.swift_version = '4.2'
   s.ios.deployment_target = '9.0'
 end

--- a/lib/mapbox_gl.dart
+++ b/lib/mapbox_gl.dart
@@ -30,7 +30,6 @@ export 'package:maplibre_gl_platform_interface/maplibre_gl_platform_interface.da
         SymbolOptions,
         CameraTargetBounds,
         MinMaxZoomPreference,
-        MapboxStyles,
         MyLocationTrackingMode,
         MyLocationRenderMode,
         CompassViewPosition,

--- a/lib/src/global.dart
+++ b/lib/src/global.dart
@@ -19,37 +19,30 @@ Future<void> installOfflineMapTiles(String tilesDb) async {
 }
 
 Future<dynamic> setOffline(
-  bool offline, {
-  String accessToken,
-}) =>
+  bool offline) =>
     _globalChannel.invokeMethod(
       'setOffline',
       <String, dynamic>{
         'offline': offline,
-        'accessToken': accessToken,
       },
     );
 
 Future<List<OfflineRegion>> mergeOfflineRegions(
-  String path, {
-  String accessToken,
-}) async {
+  String path) async {
   String regionsJson = await _globalChannel.invokeMethod(
     'mergeOfflineRegions',
     <String, dynamic>{
       'path': path,
-      'accessToken': accessToken,
     },
   );
   Iterable regions = json.decode(regionsJson);
   return regions.map((region) => OfflineRegion.fromMap(region)).toList();
 }
 
-Future<List<OfflineRegion>> getListOfRegions({String accessToken}) async {
+Future<List<OfflineRegion>> getListOfRegions() async {
   String regionsJson = await _globalChannel.invokeMethod(
     'getListOfRegions',
     <String, dynamic>{
-      'accessToken': accessToken,
     },
   );
   Iterable regions = json.decode(regionsJson);
@@ -58,14 +51,11 @@ Future<List<OfflineRegion>> getListOfRegions({String accessToken}) async {
 
 Future<OfflineRegion> updateOfflineRegionMetadata(
   int id,
-  Map<String, dynamic> metadata, {
-  String accessToken,
-}) async {
+  Map<String, dynamic> metadata) async {
   final regionJson = await _globalChannel.invokeMethod(
     'updateOfflineRegionMetadata',
     <String, dynamic>{
       'id': id,
-      'accessToken': accessToken,
       'metadata': metadata,
     },
   );
@@ -73,28 +63,25 @@ Future<OfflineRegion> updateOfflineRegionMetadata(
   return OfflineRegion.fromMap(json.decode(regionJson));
 }
 
-Future<dynamic> setOfflineTileCountLimit(int limit, {String accessToken}) =>
+Future<dynamic> setOfflineTileCountLimit(int limit) =>
     _globalChannel.invokeMethod(
       'setOfflineTileCountLimit',
       <String, dynamic>{
         'limit': limit,
-        'accessToken': accessToken,
       },
     );
 
-Future<dynamic> deleteOfflineRegion(int id, {String accessToken}) =>
+Future<dynamic> deleteOfflineRegion(int id) =>
     _globalChannel.invokeMethod(
       'deleteOfflineRegion',
       <String, dynamic>{
         'id': id,
-        'accessToken': accessToken,
       },
     );
 
 Future<OfflineRegion> downloadOfflineRegion(
   OfflineRegionDefinition definition, {
   Map<String, dynamic> metadata = const {},
-  String accessToken,
   Function(DownloadRegionStatus event) onEvent,
 }) async {
   String channelName =
@@ -102,7 +89,6 @@ Future<OfflineRegion> downloadOfflineRegion(
 
   final result =
       _globalChannel.invokeMethod('downloadOfflineRegion', <String, dynamic>{
-    'accessToken': accessToken,
     'channelName': channelName,
     'definition': definition.toMap(),
     'metadata': metadata,

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -12,7 +12,6 @@ class MaplibreMap extends StatefulWidget {
   const MaplibreMap({
     Key key,
     @required this.initialCameraPosition,
-    this.accessToken,
     this.onMapCreated,
     this.onStyleLoadedCallback,
     this.gestureRecognizers,
@@ -66,12 +65,6 @@ class MaplibreMap extends StatefulWidget {
   /// (must contain at least 1 annotation type, 4 items max)
   final List<AnnotationType> annotationConsumeTapEvents;
 
-  /// If you want to use Mapbox hosted styles and map tiles, you need to provide a Mapbox access token.
-  /// Obtain a free access token on [your Mapbox account page](https://www.mapbox.com/account/access-tokens/).
-  /// The reccommended way is to use this parameter to set your access token, an alternative way to add your access tokens through external files is described in the plugin's wiki on Github.
-  ///
-  /// Note: You should not use this parameter AND set the access token through external files at the same time, and you should use the same token throughout the entire app.
-  final String accessToken;
 
   /// Please note: you should only add annotations (e.g. symbols or circles) after `onStyleLoadedCallback` has been called.
   final MapCreatedCallback onMapCreated;
@@ -217,7 +210,6 @@ class _MaplibreMapState extends State<MaplibreMap> {
     final Map<String, dynamic> creationParams = <String, dynamic>{
       'initialCameraPosition': widget.initialCameraPosition?.toMap(),
       'options': _MapboxMapOptions.fromWidget(widget).toMap(),
-      'accessToken': widget.accessToken,
       'annotationOrder': annotationOrder,
       'annotationConsumeTapEvents': annotationConsumeTapEvents,
     };

--- a/maplibre_gl_platform_interface/lib/src/ui.dart
+++ b/maplibre_gl_platform_interface/lib/src/ui.dart
@@ -4,45 +4,6 @@
 
 part of maplibre_gl_platform_interface;
 
-class MapboxStyles {
-  static const String MAPBOX_STREETS = "mapbox://styles/mapbox/streets-v11";
-
-  /// Outdoors: A general-purpose style tailored to outdoor activities. Using this constant means
-  /// your map style will always use the latest version and may change as we improve the style.
-  static const String OUTDOORS = "mapbox://styles/mapbox/outdoors-v11";
-
-  /// Light: Subtle light backdrop for data visualizations. Using this constant means your map
-  /// style will always use the latest version and may change as we improve the style.
-  static const String LIGHT = "mapbox://styles/mapbox/light-v10";
-
-  /// Dark: Subtle dark backdrop for data visualizations. Using this constant means your map style
-  /// will always use the latest version and may change as we improve the style.
-  static const String DARK = "mapbox://styles/mapbox/dark-v10";
-
-  /// Satellite: A beautiful global satellite and aerial imagery layer. Using this constant means
-  /// your map style will always use the latest version and may change as we improve the style.
-  static const String SATELLITE = "mapbox://styles/mapbox/satellite-v9";
-
-  /// Satellite Streets: Global satellite and aerial imagery with unobtrusive labels. Using this
-  /// constant means your map style will always use the latest version and may change as we
-  /// improve the style.
-  static const String SATELLITE_STREETS =
-      "mapbox://styles/mapbox/satellite-streets-v11";
-
-  /// Traffic Day: Color-coded roads based on live traffic congestion data. Traffic data is currently
-  /// available in
-  /// <a href="https://www.mapbox.com/help/how-directions-work/#traffic-data">these select
-  /// countries</a>. Using this constant means your map style will always use the latest version and
-  /// may change as we improve the style.
-  static const String TRAFFIC_DAY = "mapbox://styles/mapbox/traffic-day-v2";
-
-  /// Traffic Night: Color-coded roads based on live traffic congestion data, designed to maximize
-  /// legibility in low-light situations. Traffic data is currently available in
-  /// <a href="https://www.mapbox.com/help/how-directions-work/#traffic-data">these select
-  /// countries</a>. Using this constant means your map style will always use the latest version and
-  /// may change as we improve the style.
-  static const String TRAFFIC_NIGHT = "mapbox://styles/mapbox/traffic-night-v2";
-}
 
 /// The camera mode, which determines how the map camera will track the rendered location.
 enum MyLocationTrackingMode {

--- a/maplibre_gl_web/lib/src/mapbox_map_controller.dart
+++ b/maplibre_gl_web/lib/src/mapbox_map_controller.dart
@@ -49,13 +49,10 @@ class MaplibreMapController extends MapLibreGlPlatform
     await _addStylesheetToShadowRoot(_mapElement);
     if (_creationParams.containsKey('initialCameraPosition')) {
       var camera = _creationParams['initialCameraPosition'];
-      if (_creationParams.containsKey('accessToken')) {
-        Mapbox.accessToken = _creationParams['accessToken'];
-      }
       _map = MapboxMap(
         MapOptions(
           container: _mapElement,
-          style: 'mapbox://styles/mapbox/streets-v11',
+          style: 'https://demotiles.maplibre.org/style.json',
           center: LngLat(camera['target'][1], camera['target'][0]),
           zoom: camera['zoom'],
           bearing: camera['bearing'],


### PR DESCRIPTION
This updates the MapLibre Android and iOS dependencies.

This removes the possibility to specify an access token. It is documented in the Readme that an access token can (if necessary) be directly included in the tile source URL.  
(In the new version of the Android library, access tokens can only be specified if a well-known tile provider is also selected. We don't support these currently, see #21)
For iOS the access token was already ignored since #9.

I also removed the MapboxStyles enum (since the `mapbox://` URLs it was using do not exist anymore in the new MapLibre versions).

Updating maplibre-gl-js is more complicated, since we rely on https://github.com/andrea689/mapbox-gl-dart, which would have to be updated or forked. (`mapboxgl` was renamed to `maplibregl` in newer versions of maplibre-gl-js)

Closes #24 
