### PR TITLE
CI: Use separate scheduled pipeline for Flutter beta builds

### DIFF
--- a/.github/workflows/flutter_beta.yml
+++ b/.github/workflows/flutter_beta.yml
@@ -1,10 +1,11 @@
-name: Flutter CI
+name: Flutter Beta CI
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  schedule:
+    - cron:  '0 0 * * *'
 
 env:
-  FLUTTER_CHANNEL: 'stable'
-  FLUTTER_VERSION: '2.5.x'
+  FLUTTER_CHANNEL: 'beta'
 
 jobs:
   format:
@@ -15,7 +16,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}
       - name: Lint analysis
         run: flutter format --set-exit-if-changed .
@@ -25,14 +25,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: subosito/flutter-action@v1
-        with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
-      - run: flutter pub get
-      - name: Lint analysis
-        run: flutter analyze
+    - uses: actions/checkout@v2
+    - uses: subosito/flutter-action@v1
+      with:
+        channel: ${{ env.FLUTTER_CHANNEL }}
+    - run: flutter pub get
+    - name: Lint analysis
+      run: flutter analyze
 
   build-android:
     name: "Build Android apk"
@@ -42,21 +41,20 @@ jobs:
         working-directory: example
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-          cache: 'gradle'
-      - uses: subosito/flutter-action@v1
-        with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
-      - run: flutter pub get
-      - name: Build example APK
-        run: flutter build apk
-          # We might want to add a flutter test step in the future, when there actually are tests for this plugin
-
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: 'gradle'
+    - uses: subosito/flutter-action@v1
+      with:
+        channel: ${{ env.FLUTTER_CHANNEL }}
+    - run: flutter pub get
+    - name: Build example APK
+      run: flutter build apk
+      # We might want to add a flutter test step in the future, when there actually are tests for this plugin
+        
   build-iOS:
     name: Build iOS package
     runs-on: macos-latest
@@ -68,7 +66,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}
       - run: flutter pub get
       - name: Update pods
@@ -90,11 +87,10 @@ jobs:
         working-directory: example
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: subosito/flutter-action@v1
-        with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
-      - run: flutter pub get
-      - name: Build web
-        run: flutter build web
+    - uses: actions/checkout@v2
+    - uses: subosito/flutter-action@v1
+      with:
+        channel: ${{ env.FLUTTER_CHANNEL }}
+    - run: flutter pub get
+    - name: Build web
+      run: flutter build web

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -13,6 +13,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Cache Flutter
+        uses: actions/cache@v1
+        with:
+          path: /opt/hostedtoolcache/flutter
+          key: ${{ runner.os }}-flutter-${{ env.FLUTTER_CHANNEL }}-${{ env.FLUTTER_VERSION }} 
       - uses: subosito/flutter-action@v1
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
@@ -26,6 +31,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Cache Flutter
+        uses: actions/cache@v1
+        with:
+          path: /opt/hostedtoolcache/flutter
+          key: ${{ runner.os }}-flutter-${{ env.FLUTTER_CHANNEL }}-${{ env.FLUTTER_VERSION }} 
       - uses: subosito/flutter-action@v1
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
@@ -48,6 +58,11 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
           cache: 'gradle'
+      - name: Cache Flutter
+        uses: actions/cache@v1
+        with:
+          path: /opt/hostedtoolcache/flutter
+          key: ${{ runner.os }}-flutter-${{ env.FLUTTER_CHANNEL }}-${{ env.FLUTTER_VERSION }} 
       - uses: subosito/flutter-action@v1
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
@@ -66,6 +81,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Cache Flutter
+        uses: actions/cache@v1
+        with:
+          path: /Users/runner/hostedtoolcache/flutter
+          key: ${{ runner.os }}-flutter-${{ env.FLUTTER_CHANNEL }}-${{ env.FLUTTER_VERSION }} 
       - uses: subosito/flutter-action@v1
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
@@ -91,6 +111,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Cache Flutter
+        uses: actions/cache@v1
+        with:
+          path: /opt/hostedtoolcache/flutter
+          key: ${{ runner.os }}-flutter-${{ env.FLUTTER_CHANNEL }}-${{ env.FLUTTER_VERSION }} 
       - uses: subosito/flutter-action@v1
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 env:
   FLUTTER_CHANNEL: 'stable'
-  FLUTTER_VERSION: '2.5.x'
+  FLUTTER_VERSION: '2.5.3'
 
 jobs:
   format:


### PR DESCRIPTION
Simple approach but should be enough for now.
Hope the caching works with `2.5.x`.
This should also speed up the single steps by a lot.