### PR TITLE
[iOS] singleTap: only require double taps to fail

### DIFF
--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
@@ -56,7 +56,8 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
             target: self,
             action: #selector(handleMapTap(sender:))
         )
-        for recognizer in mapView.gestureRecognizers! where recognizer is UITapGestureRecognizer {
+        for recognizer in mapView.gestureRecognizers!
+        where (recognizer as? UITapGestureRecognizer)?.numberOfTapsRequired == 2 {
             singleTap.require(toFail: recognizer)
         }
         mapView.addGestureRecognizer(singleTap)


### PR DESCRIPTION
Fixes #601

This diff prevents a GestureRecognizer on the native MapView's location indicator from blocking this library's `onMapClick` callback.

Taps to the compass and attribution widgets are still (properly) prevented from passing through to `onMapClick`