### PR TITLE
Fix null layer id on map click

### DIFF
--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -445,6 +445,7 @@ class MapLibreMapController extends MapLibrePlatform
       'point': Point<double>(e.point.x.toDouble(), e.point.y.toDouble()),
       'latLng': LatLng(e.lngLat.lat.toDouble(), e.lngLat.lng.toDouble()),
       if (features.isNotEmpty) "id": features.first.id,
+      if (features.isNotEmpty) "layerId": features.first.source,
     };
     if (features.isNotEmpty) {
       onFeatureTappedPlatform(payload);


### PR DESCRIPTION
### Issue:
Clicking or dragging an annotation on the web will trigger the following error because the layerId is missing from payload.
```
DartError: TypeError: null: type 'Null' is not a subtype of type 'String'
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart 307:3       throw_
dart-sdk/lib/_internal/js_dev_runtime/private/profile.dart 117:39                 _failedAsCheck
dart-sdk/lib/_internal/js_shared/lib/rti.dart 1554:3                              _generalAsCheckImplementation
packages/maplibre_gl/src/controller.dart 96:54                                    <fn>
packages/maplibre_gl_platform_interface/src/callbacks.dart 28:18                  call
packages/maplibre_gl_web/src/maplibre_web_gl_platform.dart 450:30                 [_onMapClick]
packages/maplibre_gl_web/src/util/evented.dart 69:13                              <fn>
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/operations.dart 598:37  _checkAndCall
dart-sdk/lib/_internal/js_dev_runtime/private/profile.dart 117:39                 dcall
dart-sdk/lib/_internal/js_dev_runtime/private/profile.dart 117:39                 ret
https://unpkg.com/maplibre-gl@%5E4.3/dist/maplibre-gl.js 42:9476                  fire
https://unpkg.com/maplibre-gl@%5E4.3/dist/maplibre-gl.js 46:298926                click
https://unpkg.com/maplibre-gl@%5E4.3/dist/maplibre-gl.js 46:322320                handleEvent
```
at here:
```
    _maplibrePlatform.onFeatureTappedPlatform.add((payload) {
      for (final fun
          in List<OnFeatureInteractionCallback>.from(onFeatureTapped)) {
        fun(payload["id"], payload["point"], payload["latLng"],
            payload["layerId"]);
      }
    });
```

### Fix:
Add layerId to the payload.

 
 
    