### PR TITLE
fix: Feature callbacks and new version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,17 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [0.24.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.23.0...v0.24.0)
 > **Note**: This release has breaking changes.\
-> We apologize for the quick change in 0.23.0: this version definitively stabilizes the signatures of feature interaction callbacks.
+> We apologize for the quick change in 0.24.0: this version definitively stabilizes the signatures of feature interaction callbacks.
 
 This release restores the  **feature id** and makes the `Annotation` parameter **nullable** for all feature interaction callbacks (`tap` / `drag` / `hover`).\
 This unblocks interaction with style-layer features not managed by annotation managers (i.e. added via `addLayer*` / style APIs).
 
 ### Breaking Changes
- * **Tap**: `OnFeatureInteractionCallback` → `(Point point, LatLng coordinates, String id, String layerId, Annotation? annotation)`.
+ * **Tap**: `OnFeatureInteractionCallback` → `(Point<double> point, LatLng coordinates, String id, String layerId, Annotation? annotation)`.
 
-* **Drag**: `OnFeatureDragCallback` → `(Point point, LatLng origin, LatLng current, LatLng delta, String id, String layerId, Annotation? annotation, DragEventType eventType)`.
+* **Drag**: `OnFeatureDragCallback` → `(Point<double> point, LatLng origin, LatLng current, LatLng delta, String id, Annotation? annotation, DragEventType eventType)`.
 
-* **Hover**: `OnFeatureHoverCallback` → `(Point point, LatLng coordinates, String id, String layerId, Annotation? annotation, HoverEventType eventType)`.
+* **Hover**: `OnFeatureHoverCallback` → `Point<double> point, LatLng coordinates, String id, Annotation? annotation, HoverEventType eventType)`.
 
 * **Update existing listeners**: The short‑lived 0.23.0-only signatures (without `id`) are removed.
   * For unmanaged style layer features `annotation` is `null` (`unmanaged` means sources/layers you add via style APIs like `addGeoJsonSource` + `addSymbolLayer`).
@@ -38,13 +38,12 @@ controller.onFeatureTapped.add((p, latLng, id, layerId, annotation) {
 });
 ```
 
+
+
 ### Refactor / Quality
 * (web) Refactored `onMapClick` (degenerate bbox + interactive layer filter) to surface features inserted via style APIs (unmanaged style-layer features) in `onFeatureTapped` (previously skipped; returned now with `id`, `layerId` and `annotation = null`).
 
-
-
 **Full Changelog**: [v0.23.0...v0.24.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.23.0...v0.24.0)
-
 
 ## [0.23.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.22.0...v0.23.0)
 > **Note**: This release has breaking changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,10 +38,9 @@ controller.onFeatureTapped.add((p, latLng, id, layerId, annotation) {
 });
 ```
 
-
-
 ### Refactor / Quality
-* (web) Refactored `onMapClick` (degenerate bbox + interactive layer filter) to surface features inserted via style APIs (unmanaged style-layer features) in `onFeatureTapped` (previously skipped; returned now with `id`, `layerId` and `annotation = null`).
+* (web) Refactored `onMapClick` (degenerate bbox + interactive layer filter) to surface features inserted via style APIs (unmanaged style-layer features) in `onFeatureTapped` (previously skipped; returned now with `id`, `layerId` and `annotation = null`) (##646).
+* (web) Ensure map container stretches vertically by adding `style.height = '100%'` to the registered div (prevents occasional zero-height layout issues in flexible parents) (#641)
 
 **Full Changelog**: [v0.23.0...v0.24.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.23.0...v0.24.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ controller.onFeatureTapped.add((p, latLng, id, layerId, annotation) {
 ```
 
 ### Refactor / Quality
-* (web) Refactored `onMapClick` (degenerate bbox + interactive layer filter) to surface features inserted via style APIs (unmanaged style-layer features) in `onFeatureTapped` (previously skipped; returned now with `id`, `layerId` and `annotation = null`) (##646).
+* (web) Refactored `onMapClick` (degenerate bbox + interactive layer filter) to surface features inserted via style APIs (unmanaged style-layer features) in `onFeatureTapped` (previously skipped; returned now with `id`, `layerId` and `annotation = null`) (#646).
 * (web) Ensure map container stretches vertically by adding `style.height = '100%'` to the registered div (prevents occasional zero-height layout issues in flexible parents) (#641)
 
 **Full Changelog**: [v0.23.0...v0.24.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.23.0...v0.24.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,50 @@
-# Change Log
+# CHANGELOG
 
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.24.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.23.0...v0.24.0)
+> **Note**: This release has breaking changes.\
+> We apologize for the quick change in 0.23.0: this version definitively stabilizes the signatures of feature interaction callbacks.
+
+This release restores the  **feature id** and makes the `Annotation` parameter **nullable** for all feature interaction callbacks (`tap` / `drag` / `hover`).\
+This unblocks interaction with style-layer features not managed by annotation managers (i.e. added via `addLayer*` / style APIs).
+
+### Breaking Changes
+ * **Tap**: `OnFeatureInteractionCallback` → `(Point point, LatLng coordinates, String id, String layerId, Annotation? annotation)`.
+
+* **Drag**: `OnFeatureDragCallback` → `(Point point, LatLng origin, LatLng current, LatLng delta, String id, String layerId, Annotation? annotation, DragEventType eventType)`.
+
+* **Hover**: `OnFeatureHoverCallback` → `(Point point, LatLng coordinates, String id, String layerId, Annotation? annotation, HoverEventType eventType)`.
+
+* **Update existing listeners**: The short‑lived 0.23.0-only signatures (without `id`) are removed.
+  * For unmanaged style layer features `annotation` is `null` (`unmanaged` means sources/layers you add via style APIs like `addGeoJsonSource` + `addSymbolLayer`).
+  * For managed annotations it is the `Annotation` object.
+
+### Reasoning
+In 0.23.0 the move to annotation objects inadvertently dropped interaction for unmanaged style features. Reintroducing `id` (and making `annotation` nullable) normalizes all three interaction paths without creating phantom annotation wrappers.
+
+### Migration Example
+Before (0.23.0):
+```
+controller.onFeatureTapped.add((p, latLng, annotation, layerId) {
+  print(annotation.id);
+});
+```
+After (>=0.24.0):
+```
+controller.onFeatureTapped.add((p, latLng, id, layerId, annotation) {
+  print('feature id=$id managed=${annotation != null}');
+});
+```
+
+### Refactor / Quality
+* (web) Refactored `onMapClick` (degenerate bbox + interactive layer filter) to surface features inserted via style APIs (unmanaged style-layer features) in `onFeatureTapped` (previously skipped; returned now with `id`, `layerId` and `annotation = null`).
+
+
+
+**Full Changelog**: [v0.23.0...v0.24.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.23.0...v0.24.0)
+
 
 ## [0.23.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.22.0...v0.23.0)
 > **Note**: This release has breaking changes.

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -34,7 +34,8 @@ controller.onFeatureTapped.add((p, latLng, id, layerId, annotation) {
 ```
 
 ### Refactor / Quality
-* (web) Refactored `onMapClick` (degenerate bbox + interactive layer filter) to surface features inserted via style APIs (unmanaged style-layer features) in `onFeatureTapped` (previously skipped; returned now with `id`, `layerId` and `annotation = null`).
+* (web) Refactored `onMapClick` (degenerate bbox + interactive layer filter) to surface features inserted via style APIs (unmanaged style-layer features) in `onFeatureTapped` (previously skipped; returned now with `id`, `layerId` and `annotation = null`) (##646).
+* (web) Ensure map container stretches vertically by adding `style.height = '100%'` to the registered div (prevents occasional zero-height layout issues in flexible parents) (#641)
 
 **Full Changelog**: [v0.23.0...v0.24.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.23.0...v0.24.0)
 

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -1,20 +1,23 @@
 ## [0.24.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.23.0...v0.24.0)
 > **Note**: This release has breaking changes.\
-> We apologize for the quick change in 0.23.0: this version definitively stabilizes the signatures of feature interaction callbacks.
+> We apologize for the quick change in 0.24.0: this version definitively stabilizes the signatures of feature interaction callbacks.
 
 This release restores the  **feature id** and makes the `Annotation` parameter **nullable** for all feature interaction callbacks (`tap` / `drag` / `hover`).\
 This unblocks interaction with style-layer features not managed by annotation managers (i.e. added via `addLayer*` / style APIs).
 
 ### Breaking Changes
- * **Tap**: `OnFeatureInteractionCallback` → `(Point point, LatLng coordinates, String id, String layerId, Annotation? annotation)`.
+ * **Tap**: `OnFeatureInteractionCallback` → `(Point<double> point, LatLng coordinates, String id, String layerId, Annotation? annotation)`.
 
-* **Drag**: `OnFeatureDragCallback` → `(Point point, LatLng origin, LatLng current, LatLng delta, String id, String layerId, Annotation? annotation, DragEventType eventType)`.
+* **Drag**: `OnFeatureDragCallback` → `(Point<double> point, LatLng origin, LatLng current, LatLng delta, String id, Annotation? annotation, DragEventType eventType)`.
 
-* **Hover**: `OnFeatureHoverCallback` → `(Point point, LatLng coordinates, String id, String layerId, Annotation? annotation, HoverEventType eventType)`.
+* **Hover**: `OnFeatureHoverCallback` → `Point<double> point, LatLng coordinates, String id, Annotation? annotation, HoverEventType eventType)`.
 
 * **Update existing listeners**: The short‑lived 0.23.0-only signatures (without `id`) are removed.
   * For unmanaged style layer features `annotation` is `null` (`unmanaged` means sources/layers you add via style APIs like `addGeoJsonSource` + `addSymbolLayer`).
   * For managed annotations it is the `Annotation` object.
+
+### Reasoning
+In 0.23.0 the move to annotation objects inadvertently dropped interaction for unmanaged style features. Reintroducing `id` (and making `annotation` nullable) normalizes all three interaction paths without creating phantom annotation wrappers.
 
 ### Migration Example
 Before (0.23.0):
@@ -30,8 +33,8 @@ controller.onFeatureTapped.add((p, latLng, id, layerId, annotation) {
 });
 ```
 
-### Reasoning
-In 0.23.0 the move to annotation objects inadvertently dropped interaction for unmanaged style features. Reintroducing `id` (and making `annotation` nullable) normalizes all three interaction paths without creating phantom annotation wrappers.
+### Refactor / Quality
+* (web) Refactored `onMapClick` (degenerate bbox + interactive layer filter) to surface features inserted via style APIs (unmanaged style-layer features) in `onFeatureTapped` (previously skipped; returned now with `id`, `layerId` and `annotation = null`).
 
 **Full Changelog**: [v0.23.0...v0.24.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.23.0...v0.24.0)
 

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -1,3 +1,40 @@
+## [0.24.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.23.0...v0.24.0)
+> **Note**: This release has breaking changes.\
+> We apologize for the quick change in 0.23.0: this version definitively stabilizes the signatures of feature interaction callbacks.
+
+This release restores the  **feature id** and makes the `Annotation` parameter **nullable** for all feature interaction callbacks (`tap` / `drag` / `hover`).\
+This unblocks interaction with style-layer features not managed by annotation managers (i.e. added via `addLayer*` / style APIs).
+
+### Breaking Changes
+ * **Tap**: `OnFeatureInteractionCallback` → `(Point point, LatLng coordinates, String id, String layerId, Annotation? annotation)`.
+
+* **Drag**: `OnFeatureDragCallback` → `(Point point, LatLng origin, LatLng current, LatLng delta, String id, String layerId, Annotation? annotation, DragEventType eventType)`.
+
+* **Hover**: `OnFeatureHoverCallback` → `(Point point, LatLng coordinates, String id, String layerId, Annotation? annotation, HoverEventType eventType)`.
+
+* **Update existing listeners**: The short‑lived 0.23.0-only signatures (without `id`) are removed.
+  * For unmanaged style layer features `annotation` is `null` (`unmanaged` means sources/layers you add via style APIs like `addGeoJsonSource` + `addSymbolLayer`).
+  * For managed annotations it is the `Annotation` object.
+
+### Migration Example
+Before (0.23.0):
+```
+controller.onFeatureTapped.add((p, latLng, annotation, layerId) {
+  print(annotation.id);
+});
+```
+After (>=0.24.0):
+```
+controller.onFeatureTapped.add((p, latLng, id, layerId, annotation) {
+  print('feature id=$id managed=${annotation != null}');
+});
+```
+
+### Reasoning
+In 0.23.0 the move to annotation objects inadvertently dropped interaction for unmanaged style features. Reintroducing `id` (and making `annotation` nullable) normalizes all three interaction paths without creating phantom annotation wrappers.
+
+**Full Changelog**: [v0.23.0...v0.24.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.23.0...v0.24.0)
+
 ## [0.23.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.22.0...v0.23.0)
 > **Note**: This release has breaking changes.
 

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -34,7 +34,7 @@ controller.onFeatureTapped.add((p, latLng, id, layerId, annotation) {
 ```
 
 ### Refactor / Quality
-* (web) Refactored `onMapClick` (degenerate bbox + interactive layer filter) to surface features inserted via style APIs (unmanaged style-layer features) in `onFeatureTapped` (previously skipped; returned now with `id`, `layerId` and `annotation = null`) (##646).
+* (web) Refactored `onMapClick` (degenerate bbox + interactive layer filter) to surface features inserted via style APIs (unmanaged style-layer features) in `onFeatureTapped` (previously skipped; returned now with `id`, `layerId` and `annotation = null`) (#646).
 * (web) Ensure map container stretches vertically by adding `style.height = '100%'` to the registered div (prevents occasional zero-height layout issues in flexible parents) (#641)
 
 **Full Changelog**: [v0.23.0...v0.24.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.23.0...v0.24.0)

--- a/maplibre_gl/ios/maplibre_gl.podspec
+++ b/maplibre_gl/ios/maplibre_gl.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'maplibre_gl'
-  s.version          = '0.23.0'
+  s.version          = '0.24.0'
   s.summary          = 'MapLibre GL Flutter plugin'
   s.description      = <<-DESC
 MapLibre GL Flutter plugin.

--- a/maplibre_gl/lib/src/annotation_manager.dart
+++ b/maplibre_gl/lib/src/annotation_manager.dart
@@ -146,7 +146,8 @@ abstract class AnnotationManager<T extends Annotation> {
     LatLng origin,
     LatLng current,
     LatLng delta,
-    Annotation annotation,
+    String id,
+    Annotation? annotation,
     DragEventType eventType,
   ) async {
     if (annotation is T) {
@@ -157,18 +158,18 @@ abstract class AnnotationManager<T extends Annotation> {
 
   /// Updates (re-sets) an existing annotation quickly by only replacing its
   /// underlying GeoJSON feature if it remains on the same logical layer.
-  Future<void> set(T anntotation) async {
-    assert(_idToAnnotation.containsKey(anntotation.id),
+  Future<void> set(T annotation) async {
+    assert(_idToAnnotation.containsKey(annotation.id),
         "you can only set existing annotations");
-    _idToAnnotation[anntotation.id] = anntotation;
-    final oldLayerIndex = _idToLayerIndex[anntotation.id];
-    final layerIndex = selectLayer != null ? selectLayer!(anntotation) : 0;
+    _idToAnnotation[annotation.id] = annotation;
+    final oldLayerIndex = _idToLayerIndex[annotation.id];
+    final layerIndex = selectLayer != null ? selectLayer!(annotation) : 0;
     if (oldLayerIndex != layerIndex) {
       // Layer changed; must rewrite all sources.
       await _setAll();
     } else {
       await controller.setGeoJsonFeature(
-          _makeLayerId(layerIndex), anntotation.toGeoJson());
+          _makeLayerId(layerIndex), annotation.toGeoJson());
     }
   }
 }

--- a/maplibre_gl/lib/src/controller.dart
+++ b/maplibre_gl/lib/src/controller.dart
@@ -30,7 +30,7 @@ typedef OnFeatureDragCallback = void Function(
 
 typedef OnFeatureHoverCallback = void Function(
   Point<double> point,
-  LatLng latLng,
+  LatLng coordinates,
   String id,
   Annotation? annotation,
   HoverEventType eventType,

--- a/maplibre_gl/pubspec.yaml
+++ b/maplibre_gl/pubspec.yaml
@@ -1,6 +1,6 @@
 name: maplibre_gl
 description: A Flutter plugin for integrating MapLibre Maps inside a Flutter application on Android, iOS and web platforms.
-version: 0.23.0
+version: 0.24.0
 repository: https://github.com/maplibre/flutter-maplibre-gl
 issue_tracker: https://github.com/maplibre/flutter-maplibre-gl/issues
 resolution: workspace
@@ -12,8 +12,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  maplibre_gl_platform_interface: ^0.23.0
-  maplibre_gl_web: ^0.23.0
+  maplibre_gl_platform_interface: ^0.24.0
+  maplibre_gl_web: ^0.24.0
 
 dev_dependencies:
   very_good_analysis: ^10.0.0

--- a/maplibre_gl_example/lib/layer.dart
+++ b/maplibre_gl_example/lib/layer.dart
@@ -39,122 +39,158 @@ class LayerState extends State {
 
   @override
   Widget build(BuildContext context) {
-    return ListView(children: [
-      Center(
-        child: SizedBox(
-            height: 400.0,
-            child: MapLibreMap(
-              dragEnabled: false,
-              myLocationEnabled: true,
-              onMapCreated: _onMapCreated,
-              onMapClick: (point, latLong) =>
-                  debugPrint(point.toString() + latLong.toString()),
-              onStyleLoadedCallback: _onStyleLoadedCallback,
-              initialCameraPosition: const CameraPosition(
-                target: center,
-                zoom: 11.0,
+    return Column(
+      children: [
+        Expanded(
+          child: Center(
+            child: SizedBox(
+                height: 400.0,
+                child: MapLibreMap(
+                  dragEnabled: false,
+                  myLocationEnabled: true,
+                  onMapCreated: _onMapCreated,
+                  onMapClick: (point, latLong) {
+                    debugPrint(point.toString() + latLong.toString());
+                  },
+                  onStyleLoadedCallback: _onStyleLoadedCallback,
+                  initialCameraPosition: const CameraPosition(
+                    target: center,
+                    zoom: 11.0,
+                  ),
+                )),
+          ),
+        ),
+        SingleChildScrollView(
+          child: Column(
+            children: [
+              TextButton(
+                onPressed: () async {
+                  await controller
+                      .setLayerProperties(
+                        "lines",
+                        LineLayerProperties.fromJson(
+                          {"visibility": linesVisible ? "none" : "visible"},
+                        ),
+                      )
+                      .then(
+                        (value) => setState(() => linesVisible = !linesVisible),
+                      );
+                },
+                child: const Text('toggle line visibility'),
               ),
-              annotationOrder: const [],
-            )),
-      ),
-      TextButton(
-        onPressed: () async {
-          await controller
-              .setLayerProperties(
-                  "lines",
-                  LineLayerProperties.fromJson(
-                      {"visibility": linesVisible ? "none" : "visible"}))
-              .then((value) => setState(() => linesVisible = !linesVisible));
-        },
-        child: const Text('toggle line visibility'),
-      ),
-      TextButton(
-        onPressed: () async {
-          await controller
-              .setLayerProperties(
-                  "lines",
-                  LineLayerProperties.fromJson(
-                      {"line-color": linesRed ? "#0000ff" : "#ff0000"}))
-              .then((value) => setState(() => linesRed = !linesRed));
-        },
-        child: const Text('toggle line color'),
-      ),
-      TextButton(
-        onPressed: () async {
-          await controller
-              .setLayerProperties(
-                  "fills",
-                  FillLayerProperties.fromJson(
-                      {"visibility": fillsVisible ? "none" : "visible"}))
-              .then((value) => setState(() => fillsVisible = !fillsVisible));
-        },
-        child: const Text('toggle fill visibility'),
-      ),
-      TextButton(
-        onPressed: () async {
-          await controller
-              .setLayerProperties(
-                  "fills",
-                  FillLayerProperties.fromJson(
-                      {"fill-color": fillsRed ? "#0000ff" : "#ff0000"}))
-              .then((value) => setState(() => fillsRed = !fillsRed));
-        },
-        child: const Text('toggle fill color'),
-      ),
-      TextButton(
-        onPressed: () async {
-          await controller
-              .setLayerProperties(
-                  "circles",
-                  CircleLayerProperties.fromJson(
-                      {"visibility": circlesVisible ? "none" : "visible"}))
-              .then(
-                  (value) => setState(() => circlesVisible = !circlesVisible));
-        },
-        child: const Text('toggle circle visibility'),
-      ),
-      TextButton(
-        onPressed: () async {
-          await controller
-              .setLayerProperties(
-                  "circles",
-                  CircleLayerProperties.fromJson(
-                      {"circle-color": circlesRed ? "#0000ff" : "#ff0000"}))
-              .then((value) => setState(() => circlesRed = !circlesRed));
-        },
-        child: const Text('toggle circle color'),
-      ),
-      TextButton(
-        onPressed: () async {
-          await controller
-              .setLayerProperties(
-                  "symbols",
-                  SymbolLayerProperties.fromJson(
-                      {"visibility": symbolsVisible ? "none" : "visible"}))
-              .then(
-                  (value) => setState(() => symbolsVisible = !symbolsVisible));
-        },
-        child: const Text('toggle (non-moving) symbols visibility'),
-      ),
-    ]);
+              TextButton(
+                onPressed: () async {
+                  await controller
+                      .setLayerProperties(
+                        "lines",
+                        LineLayerProperties.fromJson(
+                          {"line-color": linesRed ? "#0000ff" : "#ff0000"},
+                        ),
+                      )
+                      .then((value) => setState(() => linesRed = !linesRed));
+                },
+                child: const Text('toggle line color'),
+              ),
+              TextButton(
+                onPressed: () async {
+                  await controller
+                      .setLayerProperties(
+                        "fills",
+                        FillLayerProperties.fromJson(
+                          {"visibility": fillsVisible ? "none" : "visible"},
+                        ),
+                      )
+                      .then(
+                        (value) => setState(() => fillsVisible = !fillsVisible),
+                      );
+                },
+                child: const Text('toggle fill visibility'),
+              ),
+              TextButton(
+                onPressed: () async {
+                  await controller
+                      .setLayerProperties(
+                        "fills",
+                        FillLayerProperties.fromJson(
+                          {"fill-color": fillsRed ? "#0000ff" : "#ff0000"},
+                        ),
+                      )
+                      .then(
+                        (value) => setState(() => fillsRed = !fillsRed),
+                      );
+                },
+                child: const Text('toggle fill color'),
+              ),
+              TextButton(
+                onPressed: () async {
+                  await controller
+                      .setLayerProperties(
+                        "circles",
+                        CircleLayerProperties.fromJson(
+                          {"visibility": circlesVisible ? "none" : "visible"},
+                        ),
+                      )
+                      .then(
+                        (value) =>
+                            setState(() => circlesVisible = !circlesVisible),
+                      );
+                },
+                child: const Text('toggle circle visibility'),
+              ),
+              TextButton(
+                onPressed: () async {
+                  await controller
+                      .setLayerProperties(
+                        "circles",
+                        CircleLayerProperties.fromJson(
+                          {"circle-color": circlesRed ? "#0000ff" : "#ff0000"},
+                        ),
+                      )
+                      .then(
+                        (value) => setState(() => circlesRed = !circlesRed),
+                      );
+                },
+                child: const Text('toggle circle color'),
+              ),
+              TextButton(
+                onPressed: () async {
+                  await controller
+                      .setLayerProperties(
+                        "symbols",
+                        SymbolLayerProperties.fromJson(
+                          {"visibility": symbolsVisible ? "none" : "visible"},
+                        ),
+                      )
+                      .then(
+                        (value) =>
+                            setState(() => symbolsVisible = !symbolsVisible),
+                      );
+                },
+                child: const Text('toggle (non-moving) symbols visibility'),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
   }
 
   void _onMapCreated(MapLibreMapController controller) {
     this.controller = controller;
-
     controller.onFeatureTapped.add(onFeatureTap);
   }
 
   void onFeatureTap(
     Point<double> point,
     LatLng latLng,
-    Annotation annotation,
-    String? layerId,
+    String id,
+    String layerId,
+    Annotation? annotation,
   ) {
     final snackBar = SnackBar(
       content: Text(
-        'Tapped feature with id ${annotation.id} on layer $layerId',
-        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+        'Tapped feature with id $id on layer $layerId at $latLng.\nAnnotation is ${annotation != null ? 'present' : 'null'}',
+        style: const TextStyle(fontSize: 14),
       ),
       backgroundColor: Theme.of(context).primaryColor,
     );

--- a/maplibre_gl_example/lib/line.dart
+++ b/maplibre_gl_example/lib/line.dart
@@ -72,7 +72,8 @@ class LineBodyState extends State<LineBody> {
   Future<void> _onFeatureHover(
     Point<double> point,
     LatLng latLng,
-    Annotation annotation,
+    String id,
+    Annotation? annotation,
     HoverEventType eventType,
   ) async {
     if (annotation is! Line) return;

--- a/maplibre_gl_example/lib/place_symbol.dart
+++ b/maplibre_gl_example/lib/place_symbol.dart
@@ -92,7 +92,8 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
     LatLng origin,
     LatLng current,
     LatLng delta,
-    Annotation annotation,
+    String id,
+    Annotation? annotation,
     DragEventType eventType,
   ) {
     if (annotation is! Symbol) return;

--- a/maplibre_gl_example/pubspec.yaml
+++ b/maplibre_gl_example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_gl_example
 description: Demonstrates how to use the maplibre_gl plugin.
 publish_to: 'none'
-version: 1.0.0+1
+version: 0.24.0
 repository: https://github.com/maplibre/flutter-maplibre-gl
 issue_tracker: https://github.com/maplibre/flutter-maplibre-gl/issues
 resolution: workspace

--- a/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
+++ b/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
@@ -11,7 +11,6 @@ class MapLibreMethodChannel extends MapLibrePlatform {
         if (symbolId != null) {
           onInfoWindowTappedPlatform(symbolId);
         }
-
       case 'feature#onTap':
         final id = call.arguments['id'];
         final double x = call.arguments['x'];

--- a/maplibre_gl_platform_interface/pubspec.yaml
+++ b/maplibre_gl_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: maplibre_gl_platform_interface
 description: A common platform interface for the maplibre_gl plugin. This package is only intended to be used by the maplibre_gl package.
-version: 0.23.0
+version: 0.24.0
 repository: https://github.com/maplibre/flutter-maplibre-gl
 issue_tracker: https://github.com/maplibre/flutter-maplibre-gl/issues
 resolution: workspace

--- a/maplibre_gl_web/CHANGELOG.md
+++ b/maplibre_gl_web/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.24.0
+
+See top-level CHANGELOG.md for full details.
+
+### Refactor / Quality (web)
+* Refactored `onMapClick` (degenerate bbox + interactive layer filter) so unmanaged style-layer features now trigger `onFeatureTapped` (feature id + layer id, `annotation = null`).
+* Ensured map container stretches vertically by setting `style.height = '100%'` on the registered div to avoid zero-height issues in flexible layouts.
+
 ## 0.23.0
 
 > Note: This release has breaking changes.

--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -544,20 +544,43 @@ class MapLibreMapController extends MapLibrePlatform
     });
   }
 
+  /// Handle map click event
+  ///
+  /// If the click intersects with any features in interactive layers, trigger
+  /// `onFeatureTappedPlatform` with the first feature's info.
+  /// Otherwise, trigger `onMapClickPlatform`.
+  ///
+  /// Both events include the click point and latLng.
   void _onMapClick(Event e) {
-    final features = _map.queryRenderedFeatures([e.point.x, e.point.y],
-        {"layers": _interactiveFeatureLayerIds.toList()});
-    final payload = {
+    final pointBox = [
+      [e.point.x, e.point.y],
+      [e.point.x, e.point.y]
+    ];
+
+    // Query rendered features in the point box
+    final features = _map.queryRenderedFeatures(pointBox);
+
+    // Keep only interactive-layer features (preserve order)
+    final filtered = features
+        .where((f) => _interactiveFeatureLayerIds.contains(f.layerId))
+        .toList(growable: false);
+
+    // Prepare common payload for both events (mapClick or featureTapped)
+    final payload = <String, dynamic>{
       'point': Point<double>(e.point.x.toDouble(), e.point.y.toDouble()),
       'latLng': LatLng(e.lngLat.lat.toDouble(), e.lngLat.lng.toDouble()),
-      if (features.isNotEmpty) "id": features.first.id,
-      if (features.isNotEmpty) "layerId": features.first.layerId,
     };
-    if (features.isNotEmpty) {
-      onFeatureTappedPlatform(payload);
-    } else {
+
+    if (filtered.isEmpty) {
       onMapClickPlatform(payload);
+      return;
     }
+
+    // Add 'first' feature info to payload
+    payload['layerId'] = filtered.first.layerId;
+    payload['id'] = filtered.first.id;
+
+    onFeatureTappedPlatform(payload);
   }
 
   void _onMapLongClick(e) {

--- a/maplibre_gl_web/pubspec.yaml
+++ b/maplibre_gl_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: maplibre_gl_web
 description: Web platform implementation of maplibre_gl. This package is only intended to be used by the maplibre_gl package.
-version: 0.23.0
+version: 0.24.0
 repository: https://github.com/maplibre/flutter-maplibre-gl
 issue_tracker: https://github.com/maplibre/flutter-maplibre-gl/issues
 resolution: workspace
@@ -23,7 +23,7 @@ dependencies:
     sdk: flutter
   image: ^4.0.17
   js: ^0.7.2
-  maplibre_gl_platform_interface: ^0.23.0
+  maplibre_gl_platform_interface: ^0.24.0
   meta: ^1.3.0
 
 dev_dependencies:

--- a/scripts/pubspec.yaml
+++ b/scripts/pubspec.yaml
@@ -3,7 +3,7 @@ description: code generation for flutter-maplibre-gl
 publish_to: 'none'
 resolution: workspace
 
-version: 0.23.0
+version: 0.24.0
 
 environment:
   sdk: ">=3.5.0 <4.0.0"


### PR DESCRIPTION
This PR restores the  **feature id** and makes the `Annotation` parameter **nullable** for all feature interaction callbacks (`OnFeatureInteractionCallback ` / `OnFeatureDragCallback ` / `OnFeatureHoverCallback `).

Minor fixed on web onMapClick, bump versions and changelogs.
