### PR TITLE
fix: Rollback maplibre-gl version to 4.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Annotation tap call callbacks twice. (#652)
 * Annotation APIs: use null-aware access for manager-backed collections (symbols, lines, circles, fills) to avoid null errors before style load. (#657)
 * Add methods enforce explicit manager initialization with clear exceptions when style is not loaded. (#657)
+* Calling add* before style load now fails fast with a clear Exception instead of risking null dereferences or silent failures. (#657)
 
 ### Changed
 * Rollback maplibre-gl to `4.7.1` version. (#660)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Rollback maplibre-gl to `4.7.1` version. (#660)
 * Removed `styleString` from internal MapLibreMapOptions class. (#660)
 
+### Added
+* Added `onCameraMove` callback in the controller and in MapLibreMap class. (#643)
+
 ## [0.24.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.23.0...v0.24.0)
 > **Note**: This release has breaking changes.\
 > We apologize for the quick change in 0.24.0: this version definitively stabilizes the signatures of feature interaction callbacks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.24.1](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.24.0...v0.24.1)
+
+### Fixed
+* Annotation tap call callbacks twice. (#652)
+* Annotation APIs: use null-aware access for manager-backed collections (symbols, lines, circles, fills) to avoid null errors before style load. (#657)
+* Add methods enforce explicit manager initialization with clear exceptions when style is not loaded. (#657)
+
+### Changed
+* Rollback maplibre-gl to `4.7.1` version. (#660)
+* Removed `styleString` from internal MapLibreMapOptions class. (#660)
+
 ## [0.24.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.23.0...v0.24.0)
 > **Note**: This release has breaking changes.\
 > We apologize for the quick change in 0.24.0: this version definitively stabilizes the signatures of feature interaction callbacks.

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -1,9 +1,13 @@
-## UNRELEASED
+## [0.24.1](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.24.0...v0.24.1)
 
 ### Fixed
-* Annotation tap call callbacks twice #652
+* Annotation tap call callbacks twice. (#652)
 * Annotation APIs: use null-aware access for manager-backed collections (symbols, lines, circles, fills) to avoid null errors before style load. (#657)
 * Add methods enforce explicit manager initialization with clear exceptions when style is not loaded. (#657)
+
+### Changed
+* Rollback maplibre-gl to `4.7.1` version. (#660)
+* Removed `styleString` from internal MapLibreMapOptions class. (#660)
 
 ## [0.24.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.23.0...v0.24.0)
 > **Note**: This release has breaking changes.\

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Rollback maplibre-gl to `4.7.1` version. (#660)
 * Removed `styleString` from internal MapLibreMapOptions class. (#660)
 
+### Added
+* Added `onCameraMove` callback in the controller and in MapLibreMap class. (#643)
+
 ## [0.24.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.23.0...v0.24.0)
 > **Note**: This release has breaking changes.\
 > We apologize for the quick change in 0.24.0: this version definitively stabilizes the signatures of feature interaction callbacks.

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Annotation tap call callbacks twice. (#652)
 * Annotation APIs: use null-aware access for manager-backed collections (symbols, lines, circles, fills) to avoid null errors before style load. (#657)
 * Add methods enforce explicit manager initialization with clear exceptions when style is not loaded. (#657)
+* Calling add* before style load now fails fast with a clear Exception instead of risking null dereferences or silent failures. (#657)
 
 ### Changed
 * Rollback maplibre-gl to `4.7.1` version. (#660)

--- a/maplibre_gl/lib/src/maplibre_map.dart
+++ b/maplibre_gl/lib/src/maplibre_map.dart
@@ -109,8 +109,6 @@ class MapLibreMap extends StatefulWidget {
   final OnStyleLoadedCallback? onStyleLoadedCallback;
 
   /// The initial position of the map's camera.
-  ///
-  /// ! **This camera position will override any camera setting in the style JSON.**
   final CameraPosition initialCameraPosition;
 
   /// How long a user has to click the map **on iOS** until a long click is registered.

--- a/maplibre_gl/lib/src/maplibre_map.dart
+++ b/maplibre_gl/lib/src/maplibre_map.dart
@@ -109,7 +109,7 @@ class MapLibreMap extends StatefulWidget {
   final OnStyleLoadedCallback? onStyleLoadedCallback;
 
   /// The initial position of the map's camera.
-  /// 
+  ///
   /// ! **This camera position will override any camera setting in the style JSON.**
   final CameraPosition initialCameraPosition;
 

--- a/maplibre_gl/lib/src/maplibre_map.dart
+++ b/maplibre_gl/lib/src/maplibre_map.dart
@@ -109,6 +109,8 @@ class MapLibreMap extends StatefulWidget {
   final OnStyleLoadedCallback? onStyleLoadedCallback;
 
   /// The initial position of the map's camera.
+  /// 
+  /// ! **This camera position will override any camera setting in the style JSON.**
   final CameraPosition initialCameraPosition;
 
   /// How long a user has to click the map **on iOS** until a long click is registered.
@@ -378,7 +380,6 @@ class _MapLibreMapOptions {
   _MapLibreMapOptions(
       {this.compassEnabled,
       this.cameraTargetBounds,
-      this.styleString,
       this.minMaxZoomPreference,
       required this.rotateGesturesEnabled,
       required this.scrollGesturesEnabled,
@@ -403,7 +404,6 @@ class _MapLibreMapOptions {
           locationEnginePlatforms: map.locationEnginePlatforms,
           compassEnabled: map.compassEnabled,
           cameraTargetBounds: map.cameraTargetBounds,
-          styleString: map.styleString,
           minMaxZoomPreference: map.minMaxZoomPreference,
           rotateGesturesEnabled: map.rotateGesturesEnabled,
           scrollGesturesEnabled: map.scrollGesturesEnabled,
@@ -427,8 +427,6 @@ class _MapLibreMapOptions {
   final bool? compassEnabled;
 
   final CameraTargetBounds? cameraTargetBounds;
-
-  final String? styleString;
 
   final MinMaxZoomPreference? minMaxZoomPreference;
 
@@ -493,7 +491,6 @@ class _MapLibreMapOptions {
 
     addIfNonNull('compassEnabled', compassEnabled);
     addIfNonNull('cameraTargetBounds', cameraTargetBounds?.toJson());
-    addIfNonNull('styleString', styleString);
     addIfNonNull('minMaxZoomPreference', minMaxZoomPreference?.toJson());
 
     addIfNonNull('rotateGesturesEnabled', rotateGesturesEnabled);

--- a/maplibre_gl_example/web/index.html
+++ b/maplibre_gl_example/web/index.html
@@ -16,8 +16,8 @@
   <link rel="shortcut icon" type="image/png" href="/favicon.png"/>
 
   <!-- MapLibre -->
-  <script src='https://unpkg.com/maplibre-gl@^5.3.0/dist/maplibre-gl.js'></script>
-  <link href='https://unpkg.com/maplibre-gl@^5.3.0/dist/maplibre-gl.css' rel='stylesheet'/>
+  <script src='https://unpkg.com/maplibre-gl@^5.9.0/dist/maplibre-gl.js'></script>
+  <link href='https://unpkg.com/maplibre-gl@^5.9.0/dist/maplibre-gl.css' rel='stylesheet'/>
   <script src="https://unpkg.com/pmtiles@3.2.0/dist/pmtiles.js"></script>
 
   <title>example</title>

--- a/maplibre_gl_example/web/index.html
+++ b/maplibre_gl_example/web/index.html
@@ -16,8 +16,8 @@
   <link rel="shortcut icon" type="image/png" href="/favicon.png"/>
 
   <!-- MapLibre -->
-  <script src='https://unpkg.com/maplibre-gl@^5.9.0/dist/maplibre-gl.js'></script>
-  <link href='https://unpkg.com/maplibre-gl@^5.9.0/dist/maplibre-gl.css' rel='stylesheet'/>
+  <script src='https://unpkg.com/maplibre-gl@^4.7.1/dist/maplibre-gl.js'></script>
+  <link href='https://unpkg.com/maplibre-gl@^4.7.1/dist/maplibre-gl.css' rel='stylesheet'/>
   <script src="https://unpkg.com/pmtiles@3.2.0/dist/pmtiles.js"></script>
 
   <title>example</title>

--- a/maplibre_gl_web/CHANGELOG.md
+++ b/maplibre_gl_web/CHANGELOG.md
@@ -1,6 +1,11 @@
-## 0.24.0
+See top-level [CHANGELOG.md](../CHANGELOG.md) for full details.
 
-See top-level CHANGELOG.md for full details.
+## [0.24.1](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.24.0...v0.24.1)
+
+* Rollback maplibre-gl to `4.7.1` version. (#660)
+* Removed `styleString` from internal MapLibreMapOptions class. (#660)
+
+## 0.24.0
 
 ### Refactor / Quality (web)
 * Refactored `onMapClick` (degenerate bbox + interactive layer filter) so unmanaged style-layer features now trigger `onFeatureTapped` (feature id + layer id, `annotation = null`).

--- a/maplibre_gl_web/lib/src/convert.dart
+++ b/maplibre_gl_web/lib/src/convert.dart
@@ -19,15 +19,6 @@ class Convert {
     if (options.containsKey('compassEnabled')) {
       sink.setCompassEnabled(options['compassEnabled']);
     }
-    if (options.containsKey('styleString')) {
-      final styleString = options['styleString'];
-      if (styleString is String &&
-          (styleString.startsWith('{') || styleString.startsWith('['))) {
-        sink.setStyle(jsonDecode(styleString));
-      } else {
-        sink.setStyle(styleString);
-      }
-    }
     if (options.containsKey('minMaxZoomPreference')) {
       sink.setMinMaxZoomPreference(options['minMaxZoomPreference'][0],
           options['minMaxZoomPreference'][1]);

--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -94,7 +94,6 @@ class MapLibreMapController extends MapLibrePlatform
 
     final options = _creationParams['options'] ?? {};
     Convert.interpretMapLibreMapOptions(options, this);
-
   }
 
   void _initResizeObserver() {

--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -95,17 +95,17 @@ class MapLibreMapController extends MapLibrePlatform
     final options = _creationParams['options'] ?? {};
     Convert.interpretMapLibreMapOptions(options, this);
 
-    // If initial camera position is provided, force it after style load to override any style settings.
-    if (camera != null) {
-      _map.jumpTo(
-        CameraOptions(
-          center: LngLat(camera['target'][1], camera['target'][0]),
-          zoom: camera['zoom'],
-          bearing: camera['bearing'],
-          pitch: camera['tilt'],
-        ),
-      );
-    }
+    // // If initial camera position is provided, force it after style load to override any style settings.
+    // if (camera != null) {
+    //   _map.jumpTo(
+    //     CameraOptions(
+    //       center: LngLat(camera['target'][1], camera['target'][0]),
+    //       zoom: camera['zoom'],
+    //       bearing: camera['bearing'],
+    //       pitch: camera['tilt'],
+    //     ),
+    //   );
+    // }
   }
 
   void _initResizeObserver() {

--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -95,17 +95,6 @@ class MapLibreMapController extends MapLibrePlatform
     final options = _creationParams['options'] ?? {};
     Convert.interpretMapLibreMapOptions(options, this);
 
-    // // If initial camera position is provided, force it after style load to override any style settings.
-    // if (camera != null) {
-    //   _map.jumpTo(
-    //     CameraOptions(
-    //       center: LngLat(camera['target'][1], camera['target'][0]),
-    //       zoom: camera['zoom'],
-    //       bearing: camera['bearing'],
-    //       pitch: camera['tilt'],
-    //     ),
-    //   );
-    // }
   }
 
   void _initResizeObserver() {

--- a/maplibre_gl_web/lib/src/options_sink.dart
+++ b/maplibre_gl_web/lib/src/options_sink.dart
@@ -6,9 +6,6 @@ abstract class MapLibreMapOptionsSink {
 
   void setCompassEnabled(bool compassEnabled);
 
-  // TODO: styleString is not actually a part of options. consider moving
-  void setStyle(dynamic styleObject);
-
   void setMinMaxZoomPreference(num? min, num? max);
 
   void setGestures({


### PR DESCRIPTION
### Description
Closes #651 and #654.

- Roll back `maplibre-gl` (web) to `4.7.1` for stability/compatibility of current example, not working with >5.x versions.
  - Read in #651 the causes of the example not working.
- Remove `styleString` from internal `MapLibreMapOptions` (dead/duplicated with runtime style APIs).
- Added `styleString` handling directly to `MapLibreMap` constructor initialized.

### Impact
No public API changes; internal cleanup only. No migration required.