### PR TITLE
Implemented explicit annotation manager initialization

### DIFF
--- a/maplibre_gl/lib/src/annotation_manager.dart
+++ b/maplibre_gl/lib/src/annotation_manager.dart
@@ -4,6 +4,10 @@ part of '../maplibre_gl.dart';
 /// owning their backing style source(s)/layer(s) and performing efficient
 /// batched updates.
 ///
+/// The [initialize] method must be called before [AnnotationManager] instance
+/// can be used. Once [AnnotationManager is initialized], the [isInitialized]
+/// getter will return true.
+///
 /// An [AnnotationManager] keeps an internal mapping from annotation id to its
 /// model object and mirrors the collection into one or more GeoJSON sources;
 /// each source is bound to a style layer whose visual properties come from

--- a/maplibre_gl/lib/src/annotation_manager.dart
+++ b/maplibre_gl/lib/src/annotation_manager.dart
@@ -5,7 +5,7 @@ part of '../maplibre_gl.dart';
 /// batched updates.
 ///
 /// The [initialize] method must be called before [AnnotationManager] instance
-/// can be used. Once [AnnotationManager is initialized], the [isInitialized]
+/// can be used. Once [AnnotationManager] is initialized, the [isInitialized]
 /// getter will return true.
 ///
 /// An [AnnotationManager] keeps an internal mapping from annotation id to its

--- a/maplibre_gl/lib/src/annotation_manager.dart
+++ b/maplibre_gl/lib/src/annotation_manager.dart
@@ -66,25 +66,31 @@ abstract class AnnotationManager<T extends Annotation> {
     // Mark initialization process start, so that it cannot be entered again
     _isInitializing = true;
 
-    for (var i = 0; i < allLayerProperties.length; i++) {
-      final layerId = _makeLayerId(i);
+    try {
+      for (var i = 0; i < allLayerProperties.length; i++) {
+        final layerId = _makeLayerId(i);
 
-      await controller.addGeoJsonSource(
-        layerId,
-        buildFeatureCollection([]),
-        promoteId: "id",
-      );
-      await controller.addLayer(
-        layerId,
-        layerId,
-        allLayerProperties[i],
-        enableInteraction: enableInteraction,
-      );
+        await controller.addGeoJsonSource(
+          layerId,
+          buildFeatureCollection([]),
+          promoteId: "id",
+        );
+        await controller.addLayer(
+          layerId,
+          layerId,
+          allLayerProperties[i],
+          enableInteraction: enableInteraction,
+        );
+      }
+
+      controller.onFeatureDrag.add(_onDrag);
+
+      // Mark as initialized
+      _isInitialized = true;
+    } finally {
+      // Mark initialization process end
+      _isInitializing = false;
     }
-
-    controller.onFeatureDrag.add(_onDrag);
-
-    _isInitialized = true;
   }
 
   /// Rebuilds all backing style layers (e.g. after overlap settings changed).

--- a/maplibre_gl/lib/src/controller.dart
+++ b/maplibre_gl/lib/src/controller.dart
@@ -194,7 +194,7 @@ class MapLibreMapController extends ChangeNotifier {
       notifyListeners();
     });
 
-    _maplibrePlatform.onMapStyleLoadedPlatform.add((_) {
+    _maplibrePlatform.onMapStyleLoadedPlatform.add((_) async {
       final interactionEnabled = annotationConsumeTapEvents.toSet();
       for (final type in annotationOrder.toSet()) {
         final enableInteraction = interactionEnabled.contains(type);
@@ -204,21 +204,25 @@ class MapLibreMapController extends ChangeNotifier {
               this,
               enableInteraction: enableInteraction,
             );
+            await fillManager!.initialize();
           case AnnotationType.line:
             lineManager = LineManager(
               this,
               enableInteraction: enableInteraction,
             );
+            await lineManager!.initialize();
           case AnnotationType.circle:
             circleManager = CircleManager(
               this,
               enableInteraction: enableInteraction,
             );
+            await circleManager!.initialize();
           case AnnotationType.symbol:
             symbolManager = SymbolManager(
               this,
               enableInteraction: enableInteraction,
             );
+            await symbolManager!.initialize();
         }
       }
       onStyleLoadedCallback?.call();
@@ -1700,8 +1704,8 @@ class MapLibreMapController extends ChangeNotifier {
 
   /// Ensures that the given manager is initialized.
   /// If not, throws an [Exception].
-  void _ensureManagerInitialized(Object? manager) {
-    if (manager == null) {
+  void _ensureManagerInitialized(AnnotationManager? manager) {
+    if (manager == null || !manager.isInitialized) {
       throw Exception(
         "This Annotation Manager has not been initialized. Make sure that the map style has been loaded.",
       );

--- a/maplibre_gl_example/lib/animate_camera.dart
+++ b/maplibre_gl_example/lib/animate_camera.dart
@@ -49,194 +49,196 @@ class AnimateCameraState extends State<AnimateCamera> {
                 const CameraPosition(target: LatLng(0.0, 0.0)),
           ),
         ),
-        Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: SingleChildScrollView(
-            child: Wrap(
-              spacing: 4.0,
-              runSpacing: 4.0,
-              alignment: WrapAlignment.center,
-              children: [
-                TextButton(
-                  onPressed: () async {
-                    await mapController
-                        .animateCamera(
-                          CameraUpdate.newCameraPosition(
-                            const CameraPosition(
-                              bearing: 270.0,
-                              target: LatLng(51.5160895, -0.1294527),
-                              tilt: 30.0,
-                              zoom: 17.0,
-                            ),
-                          ),
-                        )
-                        .then(
-                          (result) => debugPrint(
-                              "mapController.animateCamera() returned $result"),
-                        );
-                  },
-                  child: const Text('newCameraPosition'),
-                ),
-                if (!kIsWeb)
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: SingleChildScrollView(
+              child: Wrap(
+                spacing: 4.0,
+                runSpacing: 4.0,
+                alignment: WrapAlignment.center,
+                children: [
                   TextButton(
                     onPressed: () async {
                       await mapController
-                          .easeCamera(
+                          .animateCamera(
                             CameraUpdate.newCameraPosition(
                               const CameraPosition(
                                 bearing: 270.0,
-                                target: LatLng(46.233487, 14.363610),
+                                target: LatLng(51.5160895, -0.1294527),
                                 tilt: 30.0,
                                 zoom: 17.0,
                               ),
                             ),
-                            duration: const Duration(seconds: 2),
                           )
                           .then(
                             (result) => debugPrint(
-                                "mapController.easeCamera() returned $result"),
+                                "mapController.animateCamera() returned $result"),
                           );
                     },
-                    child: const Text('easeCamera'),
+                    child: const Text('newCameraPosition'),
                   ),
-                TextButton(
-                  onPressed: () async {
-                    await mapController
-                        .animateCamera(
-                          CameraUpdate.newLatLng(
-                            const LatLng(56.1725505, 10.1850512),
-                          ),
-                          duration: const Duration(seconds: 5),
-                        )
-                        .then((result) => debugPrint(
-                            "mapController.animateCamera() returned $result"));
-                  },
-                  child: const Text('newLatLng'),
-                ),
-                TextButton(
-                  onPressed: () async {
-                    await mapController.animateCamera(
-                      CameraUpdate.newLatLngBounds(
-                        LatLngBounds(
-                          southwest: const LatLng(-38.483935, 113.248673),
-                          northeast: const LatLng(-8.982446, 153.823821),
-                        ),
-                        left: 10,
-                        top: 5,
-                        bottom: 25,
-                      ),
-                    );
-                  },
-                  child: const Text('newLatLngBounds'),
-                ),
-                TextButton(
-                  onPressed: () async {
-                    await mapController.animateCamera(
-                      CameraUpdate.newLatLngZoom(
-                        const LatLng(37.4231613, -122.087159),
-                        11.0,
-                      ),
-                    );
-                  },
-                  child: const Text('newLatLngZoom'),
-                ),
-                TextButton(
-                  onPressed: () async {
-                    await mapController.animateCamera(
-                      CameraUpdate.scrollBy(150.0, -225.0),
-                    );
-                  },
-                  child: const Text('scrollBy'),
-                ),
-                if (!kIsWeb)
+                  if (!kIsWeb)
+                    TextButton(
+                      onPressed: () async {
+                        await mapController
+                            .easeCamera(
+                              CameraUpdate.newCameraPosition(
+                                const CameraPosition(
+                                  bearing: 270.0,
+                                  target: LatLng(46.233487, 14.363610),
+                                  tilt: 30.0,
+                                  zoom: 17.0,
+                                ),
+                              ),
+                              duration: const Duration(seconds: 2),
+                            )
+                            .then(
+                              (result) => debugPrint(
+                                  "mapController.easeCamera() returned $result"),
+                            );
+                      },
+                      child: const Text('easeCamera'),
+                    ),
                   TextButton(
                     onPressed: () async {
-                      await mapController.queryCameraPosition().then(
-                            (result) => debugPrint(
-                                "queryCameraPosition() returned $result"),
-                          );
+                      await mapController
+                          .animateCamera(
+                            CameraUpdate.newLatLng(
+                              const LatLng(56.1725505, 10.1850512),
+                            ),
+                            duration: const Duration(seconds: 5),
+                          )
+                          .then((result) => debugPrint(
+                              "mapController.animateCamera() returned $result"));
                     },
-                    child: const Text('queryCameraPosition'),
+                    child: const Text('newLatLng'),
                   ),
-                TextButton(
-                  onPressed: () async {
-                    _fps = _fps == 30 ? 3 : 30;
-                    await mapController.setMaximumFps(_fps);
-                  },
-                  child: const Text('setMaximumFps'),
-                ),
-                TextButton(
-                  onPressed: () async {
-                    await mapController.animateCamera(
-                      CameraUpdate.zoomBy(
-                        -0.5,
-                        const Offset(30.0, 20.0),
-                      ),
-                    );
-                  },
-                  child: const Text('zoomBy with focus'),
-                ),
-                TextButton(
-                  onPressed: () async {
-                    await mapController.animateCamera(
-                      CameraUpdate.newLatLngZoom(const LatLng(48, 11), 5),
-                      duration: const Duration(milliseconds: 300),
-                    );
-                  },
-                  child: const Text('latlngZoom'),
-                ),
-                TextButton(
-                  onPressed: () async {
-                    await mapController.animateCamera(
-                      CameraUpdate.zoomBy(-0.5),
-                    );
-                  },
-                  child: const Text('zoomBy'),
-                ),
-                TextButton(
-                  onPressed: () async {
-                    await mapController.animateCamera(
-                      CameraUpdate.zoomIn(),
-                    );
-                  },
-                  child: const Text('zoomIn'),
-                ),
-                TextButton(
-                  onPressed: () async {
-                    await mapController.animateCamera(
-                      CameraUpdate.zoomOut(),
-                    );
-                  },
-                  child: const Text('zoomOut'),
-                ),
-                TextButton(
-                  onPressed: () async {
-                    await mapController.animateCamera(
-                      CameraUpdate.zoomTo(16.0),
-                    );
-                  },
-                  child: const Text('zoomTo'),
-                ),
-                TextButton(
-                  onPressed: () async {
-                    await mapController.animateCamera(
-                      CameraUpdate.bearingTo(45.0),
-                    );
-                  },
-                  child: const Text('bearingTo'),
-                ),
-                TextButton(
-                  onPressed: () async {
-                    await mapController.animateCamera(
-                      CameraUpdate.tiltTo(30.0),
-                    );
-                  },
-                  child: const Text('tiltTo'),
-                ),
-              ],
+                  TextButton(
+                    onPressed: () async {
+                      await mapController.animateCamera(
+                        CameraUpdate.newLatLngBounds(
+                          LatLngBounds(
+                            southwest: const LatLng(-38.483935, 113.248673),
+                            northeast: const LatLng(-8.982446, 153.823821),
+                          ),
+                          left: 10,
+                          top: 5,
+                          bottom: 25,
+                        ),
+                      );
+                    },
+                    child: const Text('newLatLngBounds'),
+                  ),
+                  TextButton(
+                    onPressed: () async {
+                      await mapController.animateCamera(
+                        CameraUpdate.newLatLngZoom(
+                          const LatLng(37.4231613, -122.087159),
+                          11.0,
+                        ),
+                      );
+                    },
+                    child: const Text('newLatLngZoom'),
+                  ),
+                  TextButton(
+                    onPressed: () async {
+                      await mapController.animateCamera(
+                        CameraUpdate.scrollBy(150.0, -225.0),
+                      );
+                    },
+                    child: const Text('scrollBy'),
+                  ),
+                  if (!kIsWeb)
+                    TextButton(
+                      onPressed: () async {
+                        await mapController.queryCameraPosition().then(
+                              (result) => debugPrint(
+                                  "queryCameraPosition() returned $result"),
+                            );
+                      },
+                      child: const Text('queryCameraPosition'),
+                    ),
+                  TextButton(
+                    onPressed: () async {
+                      _fps = _fps == 30 ? 3 : 30;
+                      await mapController.setMaximumFps(_fps);
+                    },
+                    child: const Text('setMaximumFps'),
+                  ),
+                  TextButton(
+                    onPressed: () async {
+                      await mapController.animateCamera(
+                        CameraUpdate.zoomBy(
+                          -0.5,
+                          const Offset(30.0, 20.0),
+                        ),
+                      );
+                    },
+                    child: const Text('zoomBy with focus'),
+                  ),
+                  TextButton(
+                    onPressed: () async {
+                      await mapController.animateCamera(
+                        CameraUpdate.newLatLngZoom(const LatLng(48, 11), 5),
+                        duration: const Duration(milliseconds: 300),
+                      );
+                    },
+                    child: const Text('latlngZoom'),
+                  ),
+                  TextButton(
+                    onPressed: () async {
+                      await mapController.animateCamera(
+                        CameraUpdate.zoomBy(-0.5),
+                      );
+                    },
+                    child: const Text('zoomBy'),
+                  ),
+                  TextButton(
+                    onPressed: () async {
+                      await mapController.animateCamera(
+                        CameraUpdate.zoomIn(),
+                      );
+                    },
+                    child: const Text('zoomIn'),
+                  ),
+                  TextButton(
+                    onPressed: () async {
+                      await mapController.animateCamera(
+                        CameraUpdate.zoomOut(),
+                      );
+                    },
+                    child: const Text('zoomOut'),
+                  ),
+                  TextButton(
+                    onPressed: () async {
+                      await mapController.animateCamera(
+                        CameraUpdate.zoomTo(16.0),
+                      );
+                    },
+                    child: const Text('zoomTo'),
+                  ),
+                  TextButton(
+                    onPressed: () async {
+                      await mapController.animateCamera(
+                        CameraUpdate.bearingTo(45.0),
+                      );
+                    },
+                    child: const Text('bearingTo'),
+                  ),
+                  TextButton(
+                    onPressed: () async {
+                      await mapController.animateCamera(
+                        CameraUpdate.tiltTo(30.0),
+                      );
+                    },
+                    child: const Text('tiltTo'),
+                  ),
+                ],
+              ),
             ),
           ),
-        )
+        ),
       ],
     );
   }


### PR DESCRIPTION
This PR separates `AnnotationManager` initialization logic into a separate `initialize()` method which can be awaited. This way annotation managers can be predictably initialized.

Previous initialization logic possibly led to situations where the manager was used before its initialization finished. It is practically impossible to avoid it because you cannot know if and when does the initialization finish. This was especially the case when creating custom `AnnotationManager` instances on the fly.

This changes how annotation managers are used and users are now required to call `initialize()` before using the manager, so this is a breaking change.

Also map style loaded callback is now only called after all the managers finished loading, which adds some possibly unnecessary load time, but prevents some nasty errors.

### Alternatives?

I'm open to different solutions - normally I'm opposed to initialization methods which have to be called manually, but here it seemed like to most straightforward solution. It is a bit clunky with the `_initilizing` and `_initialized` flags, I'll admit that.
