### PR TITLE
Return all targets when supplying empty layers list on iOS

### DIFF
--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
@@ -254,7 +254,7 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
         case "map#queryRenderedFeatures":
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
             var styleLayerIdentifiers: Set<String>?
-            if let layerIds = arguments["layerIds"] as? [String] {
+            if let layerIds = arguments["layerIds"] as? [String], !layerIds.isEmpty {
                 styleLayerIdentifiers = Set<String>(layerIds)
             }
             var filterExpression: NSPredicate?


### PR DESCRIPTION
This PR fixes a bug on iOS when calling queryRenderedFeatures.

If you supply an empy array list, none of the targets are returned, which is contrary to what happens on Android.