### PR TITLE
feat(web): Add Scale Control

### DIFF
--- a/maplibre_gl/lib/maplibre_gl.dart
+++ b/maplibre_gl/lib/maplibre_gl.dart
@@ -78,6 +78,8 @@ export 'package:maplibre_gl_platform_interface/maplibre_gl_platform_interface.da
         OnPlatformViewCreatedCallback,
         RasterDemSourceProperties,
         RasterSourceProperties,
+        ScaleControlPosition,
+        ScaleControlUnit,
         SourceProperties,
         Symbol,
         SymbolOptions,

--- a/maplibre_gl/lib/src/maplibre_map.dart
+++ b/maplibre_gl/lib/src/maplibre_map.dart
@@ -42,6 +42,9 @@ class MapLibreMap extends StatefulWidget {
     this.compassViewMargins,
     this.attributionButtonPosition = AttributionButtonPosition.bottomRight,
     this.attributionButtonMargins,
+    this.scaleControlEnabled = false,
+    this.scaleControlPosition = ScaleControlPosition.bottomLeft,
+    this.scaleControlUnit = ScaleControlUnit.metric,
     this.iosLongClickDuration,
     this.webPreserveDrawingBuffer = false,
     this.onMapClick,
@@ -237,6 +240,21 @@ class MapLibreMap extends StatefulWidget {
   /// different defaults.
   final Point? attributionButtonMargins;
 
+  /// True if the scale control should be shown on the map.
+  /// Defaults to false.
+  /// **Web only** - has no effect on other platforms.
+  final bool scaleControlEnabled;
+
+  /// Set the position for the Scale Control.
+  /// Defaults to [ScaleControlPosition.bottomLeft].
+  /// **Web only** - has no effect on other platforms.
+  final ScaleControlPosition scaleControlPosition;
+
+  /// Set the unit for the Scale Control.
+  /// Defaults to [ScaleControlUnit.metric].
+  /// **Web only** - has no effect on other platforms.
+  final ScaleControlUnit scaleControlUnit;
+
   /// Which gestures should be consumed by the map.
   ///
   /// It is possible for other gesture recognizers to be competing with the map on pointer
@@ -408,6 +426,9 @@ class _MapLibreMapOptions {
       this.compassViewMargins,
       this.attributionButtonPosition,
       this.attributionButtonMargins,
+      this.scaleControlEnabled,
+      this.scaleControlPosition,
+      this.scaleControlUnit,
       this.locationEnginePlatforms,
       this.foregroundLoadColor,
       this.translucentTextureSurface});
@@ -436,6 +457,9 @@ class _MapLibreMapOptions {
           compassViewMargins: map.compassViewMargins,
           attributionButtonPosition: map.attributionButtonPosition,
           attributionButtonMargins: map.attributionButtonMargins,
+          scaleControlEnabled: map.scaleControlEnabled,
+          scaleControlPosition: map.scaleControlPosition,
+          scaleControlUnit: map.scaleControlUnit,
           foregroundLoadColor: map.foregroundLoadColor,
           translucentTextureSurface: map.translucentTextureSurface,
         );
@@ -479,6 +503,12 @@ class _MapLibreMapOptions {
   final AttributionButtonPosition? attributionButtonPosition;
 
   final Point? attributionButtonMargins;
+
+  final bool? scaleControlEnabled;
+
+  final ScaleControlPosition? scaleControlPosition;
+
+  final ScaleControlUnit? scaleControlUnit;
 
   final LocationEnginePlatforms? locationEnginePlatforms;
 
@@ -534,6 +564,9 @@ class _MapLibreMapOptions {
     addIfNonNull('attributionButtonPosition', attributionButtonPosition?.index);
     addIfNonNull(
         'attributionButtonMargins', pointToArray(attributionButtonMargins));
+    addIfNonNull('scaleControlEnabled', scaleControlEnabled);
+    addIfNonNull('scaleControlPosition', scaleControlPosition?.index);
+    addIfNonNull('scaleControlUnit', scaleControlUnit?.index);
     addIfNonNull('locationEngineProperties', locationEnginePlatforms?.toList());
     addIfNonNull('foregroundLoadColor', foregroundLoadColor?.toARGB32());
     addIfNonNull('translucentTextureSurface', translucentTextureSurface);

--- a/maplibre_gl_platform_interface/lib/src/ui.dart
+++ b/maplibre_gl_platform_interface/lib/src/ui.dart
@@ -48,6 +48,21 @@ enum LogoViewPosition {
   bottomRight,
 }
 
+/// Scale Control Position
+enum ScaleControlPosition {
+  topLeft,
+  topRight,
+  bottomLeft,
+  bottomRight,
+}
+
+/// Scale Control Unit
+enum ScaleControlUnit {
+  metric,
+  imperial,
+  nautical,
+}
+
 /// Bounds for the map camera target.
 /// Used with [_MapLibreMapOptions] to wrap a [LatLngBounds] value. This allows
 /// distinguishing between specifying an unbounded target (null `LatLngBounds`)

--- a/maplibre_gl_web/lib/maplibre_gl_web.dart
+++ b/maplibre_gl_web/lib/maplibre_gl_web.dart
@@ -30,6 +30,7 @@ import 'package:maplibre_gl_web/src/ui/camera.dart';
 import 'package:maplibre_gl_web/src/ui/control/attribution_control.dart';
 import 'package:maplibre_gl_web/src/ui/control/geolocate_control.dart';
 import 'package:maplibre_gl_web/src/ui/control/navigation_control.dart';
+import 'package:maplibre_gl_web/src/ui/control/scale_control.dart';
 import 'package:maplibre_gl_web/src/ui/map.dart';
 import 'package:maplibre_gl_web/src/util/evented.dart';
 import 'package:maplibre_gl_web/src/utils.dart';

--- a/maplibre_gl_web/lib/src/convert.dart
+++ b/maplibre_gl_web/lib/src/convert.dart
@@ -91,6 +91,18 @@ class Convert {
       sink.setAttributionButtonMargins(options['attributionButtonMargins'][0],
           options['attributionButtonMargins'][1]);
     }
+    if (options.containsKey('scaleControlEnabled')) {
+      sink.setScaleControlEnabled(options['scaleControlEnabled']);
+    }
+    if (options.containsKey('scaleControlPosition')) {
+      final position =
+          ScaleControlPosition.values[options['scaleControlPosition']];
+      sink.setScaleControlPosition(position);
+    }
+    if (options.containsKey('scaleControlUnit')) {
+      final unit = ScaleControlUnit.values[options['scaleControlUnit']];
+      sink.setScaleControlUnit(unit);
+    }
   }
 
   static CameraOptions toCameraOptions(

--- a/maplibre_gl_web/lib/src/interop/interop.dart
+++ b/maplibre_gl_web/lib/src/interop/interop.dart
@@ -16,6 +16,7 @@ export 'ui/camera_interop.dart';
 export 'ui/control/geolocate_control_interop.dart';
 export 'ui/control/logo_control_interop.dart';
 export 'ui/control/navigation_control_interop.dart';
+export 'ui/control/scale_control_interop.dart';
 export 'ui/events_interop.dart';
 export 'ui/handler/box_zoom_interop.dart';
 export 'ui/handler/dblclick_zoom_interop.dart';

--- a/maplibre_gl_web/lib/src/interop/ui/control/scale_control_interop.dart
+++ b/maplibre_gl_web/lib/src/interop/ui/control/scale_control_interop.dart
@@ -1,0 +1,37 @@
+@JS('maplibregl')
+library;
+
+import 'dart:js_interop';
+import 'package:maplibre_gl_web/src/interop/ui/map_interop.dart';
+
+/// JS interop class for the ScaleControl options.
+extension type ScaleControlOptionsJsImpl._(JSObject _) implements JSObject {
+  external num get maxWidth;
+  external String get unit;
+
+  external factory ScaleControlOptionsJsImpl({
+    num? maxWidth,
+    String? unit,
+  });
+}
+
+/// A `ScaleControl` control displays the ratio of a distance on the map
+/// to the corresponding distance on the ground.
+///
+/// @implements {IControl}
+/// @param {Object} [options]
+/// @param {Number} [options.maxWidth=100] The maximum length of the scale control in pixels.
+/// @param {String} [options.unit='metric'] Unit of the distance ('imperial', 'metric' or 'nautical').
+@JS('ScaleControl')
+@staticInterop
+class ScaleControlJsImpl {
+  external factory ScaleControlJsImpl(ScaleControlOptionsJsImpl options);
+}
+
+extension ScaleControlJsImplExtension on ScaleControlJsImpl {
+  external ScaleControlOptionsJsImpl get options;
+  external JSAny? onAdd(MapLibreMapJsImpl map);
+  external void onRemove();
+  external String getDefaultPosition();
+  external void setUnit(String unit);
+}

--- a/maplibre_gl_web/lib/src/interop/ui/control/scale_control_interop.dart
+++ b/maplibre_gl_web/lib/src/interop/ui/control/scale_control_interop.dart
@@ -2,6 +2,7 @@
 library;
 
 import 'dart:js_interop';
+
 import 'package:maplibre_gl_web/src/interop/ui/map_interop.dart';
 
 /// JS interop class for the ScaleControl options.
@@ -25,11 +26,11 @@ extension type ScaleControlOptionsJsImpl._(JSObject _) implements JSObject {
 @JS('ScaleControl')
 @staticInterop
 class ScaleControlJsImpl {
-  external factory ScaleControlJsImpl(ScaleControlOptionsJsImpl options);
+  external factory ScaleControlJsImpl([ScaleControlOptionsJsImpl? options]);
 }
 
 extension ScaleControlJsImplExtension on ScaleControlJsImpl {
-  external ScaleControlOptionsJsImpl get options;
+  external ScaleControlOptionsJsImpl? get options;
   external JSAny? onAdd(MapLibreMapJsImpl map);
   external void onRemove();
   external String getDefaultPosition();

--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -90,6 +90,15 @@ class MapLibreMapController extends MapLibrePlatform
       _map.on('mousemove', _onMouseMove);
     }
 
+    // Add scale control
+    final scaleControl = ScaleControl(
+      ScaleControlOptions(
+        maxWidth: 80,
+        unit: 'metric',
+      ),
+    );
+    _map.addControl(scaleControl, 'bottom-right');
+
     _initResizeObserver();
 
     final options = _creationParams['options'] ?? {};

--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -22,6 +22,8 @@ class MapLibreMapController extends MapLibrePlatform
   String? _navigationControlPosition;
   NavigationControl? _navigationControl;
   AttributionControl? _attributionControl;
+  ScaleControl? _scaleControl;
+  String? _scaleControlPosition;
   Timer? lastResizeObserverTimer;
 
   @override
@@ -89,15 +91,6 @@ class MapLibreMapController extends MapLibrePlatform
       _map.on('mouseup', _onMouseUp);
       _map.on('mousemove', _onMouseMove);
     }
-
-    // Add scale control
-    final scaleControl = ScaleControl(
-      ScaleControlOptions(
-        maxWidth: 80,
-        unit: 'metric',
-      ),
-    );
-    _map.addControl(scaleControl, 'bottom-right');
 
     _initResizeObserver();
 
@@ -782,6 +775,69 @@ class MapLibreMapController extends MapLibrePlatform
   @override
   void setAttributionButtonMargins(int x, int y) {
     print('setAttributionButtonMargins not available in web');
+  }
+
+  @override
+  void setScaleControlEnabled(bool enabled) {
+    if (enabled) {
+      _addScaleControl();
+    } else {
+      _removeScaleControl();
+    }
+  }
+
+  @override
+  void setScaleControlPosition(ScaleControlPosition position) {
+    final positionString = switch (position) {
+      ScaleControlPosition.topLeft => 'top-left',
+      ScaleControlPosition.topRight => 'top-right',
+      ScaleControlPosition.bottomLeft => 'bottom-left',
+      ScaleControlPosition.bottomRight => 'bottom-right',
+    };
+    // Only re-add if position changed
+    if (_scaleControl != null && _scaleControlPosition != positionString) {
+      _addScaleControl(position: position);
+    }
+  }
+
+  @override
+  void setScaleControlUnit(ScaleControlUnit unit) {
+    if (_scaleControl != null) {
+      final unitString = switch (unit) {
+        ScaleControlUnit.metric => 'metric',
+        ScaleControlUnit.imperial => 'imperial',
+        ScaleControlUnit.nautical => 'nautical',
+      };
+      _scaleControl!.setUnit(unitString);
+    }
+  }
+
+  void _addScaleControl({ScaleControlPosition? position}) {
+    _removeScaleControl();
+
+    final positionString =
+        switch (position ?? ScaleControlPosition.bottomLeft) {
+      ScaleControlPosition.topLeft => 'top-left',
+      ScaleControlPosition.topRight => 'top-right',
+      ScaleControlPosition.bottomLeft => 'bottom-left',
+      ScaleControlPosition.bottomRight => 'bottom-right',
+    };
+
+    _scaleControl = ScaleControl(
+      ScaleControlOptions(
+        maxWidth: 80,
+      ),
+    );
+    _scaleControlPosition = positionString;
+    _map.addControl(_scaleControl, positionString);
+  }
+
+  void _removeScaleControl() {
+    if (_scaleControl != null) {
+      _map.removeControl(_scaleControl);
+      _scaleControl = null;
+      _scaleControlPosition = null;
+    }
   }
 
   @override

--- a/maplibre_gl_web/lib/src/options_sink.dart
+++ b/maplibre_gl_web/lib/src/options_sink.dart
@@ -38,4 +38,10 @@ abstract class MapLibreMapOptionsSink {
   void setAttributionButtonAlignment(AttributionButtonPosition position);
 
   void setAttributionButtonMargins(int x, int y);
+
+  void setScaleControlEnabled(bool enabled);
+
+  void setScaleControlPosition(ScaleControlPosition position);
+
+  void setScaleControlUnit(ScaleControlUnit unit);
 }

--- a/maplibre_gl_web/lib/src/ui/control/scale_control.dart
+++ b/maplibre_gl_web/lib/src/ui/control/scale_control.dart
@@ -30,9 +30,11 @@ class ScaleControlOptions extends JsObjectWrapper<ScaleControlOptionsJsImpl> {
 /// Displays the ratio of a distance on the map to the corresponding distance
 /// on the ground. You can change units dynamically via [setUnit].
 class ScaleControl extends JsObjectWrapper<ScaleControlJsImpl> {
-  /// Access to the underlying JS options.
-  ScaleControlOptions get options =>
-      ScaleControlOptions.fromJsObject(jsObject.options);
+  /// Access to the underlying JS options, or null if created with defaults.
+  ScaleControlOptions? get options {
+    final opts = jsObject.options;
+    return opts != null ? ScaleControlOptions.fromJsObject(opts) : null;
+  }
 
   /// Creates a new ScaleControl with the given [options].
   factory ScaleControl(ScaleControlOptions options) {

--- a/maplibre_gl_web/lib/src/ui/control/scale_control.dart
+++ b/maplibre_gl_web/lib/src/ui/control/scale_control.dart
@@ -1,0 +1,58 @@
+import 'package:maplibre_gl_web/src/interop/interop.dart';
+import 'package:maplibre_gl_web/src/ui/map.dart';
+
+/// Dart wrapper around [ScaleControlOptionsJsImpl].
+class ScaleControlOptions extends JsObjectWrapper<ScaleControlOptionsJsImpl> {
+  /// Maximum width of the scale control in pixels.
+  num get maxWidth => jsObject.maxWidth;
+
+  /// Unit of the distance (e.g. "metric", "imperial", or "nautical").
+  String get unit => jsObject.unit;
+
+  factory ScaleControlOptions({
+    num? maxWidth,
+    String? unit,
+  }) {
+    return ScaleControlOptions.fromJsObject(
+      ScaleControlOptionsJsImpl(
+        maxWidth: maxWidth,
+        unit: unit,
+      ),
+    );
+  }
+
+  /// Create a new [ScaleControlOptions] from a [jsObject].
+  ScaleControlOptions.fromJsObject(super.jsObject) : super.fromJsObject();
+}
+
+/// Dart wrapper around [ScaleControlJsImpl].
+///
+/// Displays the ratio of a distance on the map to the corresponding distance
+/// on the ground. You can change units dynamically via [setUnit].
+class ScaleControl extends JsObjectWrapper<ScaleControlJsImpl> {
+  /// Access to the underlying JS options.
+  ScaleControlOptions get options =>
+      ScaleControlOptions.fromJsObject(jsObject.options);
+
+  /// Creates a new ScaleControl with the given [options].
+  factory ScaleControl(ScaleControlOptions options) {
+    return ScaleControl.fromJsObject(
+      ScaleControlJsImpl(options.jsObject),
+    );
+  }
+
+  /// Create a [ScaleControl] from an existing [ScaleControlJsImpl].
+  ScaleControl.fromJsObject(super.jsObject) : super.fromJsObject();
+
+  /// Add this control to the given [map].
+  dynamic onAdd(MapLibreMap map) => jsObject.onAdd(map.jsObject);
+
+  /// Remove this control from the map.
+  dynamic onRemove() => jsObject.onRemove();
+
+  /// Return the default position for this control ("bottom-left").
+  String getDefaultPosition() => jsObject.getDefaultPosition();
+
+  /// Set the scale’s unit of distance (e.g. "imperial", "metric", "nautical").
+  void setUnit(String unit) => jsObject.setUnit(unit);
+}


### PR DESCRIPTION
Displays the ratio of map distance to ground distance on web maps. Uses the new dart:js_interop pattern compatible with 0.25.0.

- Added scale_control_interop.dart with ScaleControlJsImpl
- Added scale_control.dart wrapper class
- Updated interop.dart exports
- Added ScaleControl to map initialization

Closes #143 