### PR TITLE
feat(web): Add get layer visibility, web snapshot, and map sizing features

### DIFF
--- a/maplibre_gl/lib/src/controller.dart
+++ b/maplibre_gl/lib/src/controller.dart
@@ -1688,6 +1688,37 @@ class MapLibreMapController extends ChangeNotifier {
         .toList();
   }
 
+  /// Returns the visibility of a layer.
+  /// Returns true if visible, false if hidden, null if layer not found.
+  Future<bool?> getLayerVisibility(String layerId) {
+    return _maplibrePlatform.getLayerVisibility(layerId);
+  }
+
+  /// Sets the web map to a custom size for rendering.
+  /// Returns the actual size that was set.
+  /// Useful for generating fixed-dimension map images.
+  Future<Size> setWebMapToCustomSize(Size size) {
+    return _maplibrePlatform.setWebMapToCustomSize(size);
+  }
+
+  /// Waits until the map is idle after camera movement.
+  Future<void> waitUntilMapIsIdleAfterMovement() {
+    return _maplibrePlatform.waitUntilMapIsIdleAfterMovement();
+  }
+
+  /// Waits until all visible map tiles are loaded.
+  /// Useful for ensuring the map is fully rendered before taking screenshots.
+  Future<void> waitUntilMapTilesAreLoaded() {
+    return _maplibrePlatform.waitUntilMapTilesAreLoaded();
+  }
+
+  /// Takes a screenshot of the web map.
+  /// Returns a base64-encoded PNG image string.
+  /// Only supported on web platform.
+  Future<String> takeWebSnapshot() {
+    return _maplibrePlatform.takeWebSnapshot();
+  }
+
   /// Method to set style string
   /// A MapLibre GL style document defining the map's appearance.
   /// The style document specification is at [https://maplibre.org/maplibre-style-spec].

--- a/maplibre_gl/lib/src/controller.dart
+++ b/maplibre_gl/lib/src/controller.dart
@@ -1695,7 +1695,7 @@ class MapLibreMapController extends ChangeNotifier {
   }
 
   /// Sets the web map to a custom size for rendering.
-  /// Returns the actual size that was set.
+  /// Returns the previous size before this change was applied.
   /// Useful for generating fixed-dimension map images.
   Future<Size> setWebMapToCustomSize(Size size) {
     return _maplibrePlatform.setWebMapToCustomSize(size);

--- a/maplibre_gl_example/lib/examples/advanced/map_snapshot.dart
+++ b/maplibre_gl_example/lib/examples/advanced/map_snapshot.dart
@@ -1,0 +1,277 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:maplibre_gl/maplibre_gl.dart';
+
+import '../../page.dart';
+import '../../shared/shared.dart';
+
+/// Example demonstrating map snapshot functionality
+///
+/// This example shows how to:
+/// - Take a snapshot of the current map view (web only)
+/// - Set a custom size for the map before taking a snapshot
+/// - Display the captured snapshot in a dialog
+class MapSnapshotPage extends ExamplePage {
+  const MapSnapshotPage({super.key})
+      : super(
+          const Icon(Icons.camera_alt),
+          'Map Snapshot',
+          category: ExampleCategory.advanced,
+        );
+
+  @override
+  Widget build(BuildContext context) => const _MapSnapshotBody();
+}
+
+class _MapSnapshotBody extends StatefulWidget {
+  const _MapSnapshotBody();
+
+  @override
+  State<_MapSnapshotBody> createState() => _MapSnapshotBodyState();
+}
+
+class _MapSnapshotBodyState extends State<_MapSnapshotBody> {
+  MapLibreMapController? _mapController;
+  bool _canInteractWithMap = false;
+  bool _isCapturing = false;
+  Size? _customSize;
+
+  void _onMapCreated(MapLibreMapController controller) {
+    _mapController = controller;
+  }
+
+  void _onStyleLoaded() {
+    setState(() => _canInteractWithMap = true);
+  }
+
+  /// Takes a snapshot of the current map view
+  Future<void> _takeSnapshot() async {
+    if (_mapController == null || !kIsWeb) return;
+
+    setState(() => _isCapturing = true);
+
+    try {
+      // Wait for any pending tiles to load
+      await _mapController!.waitUntilMapTilesAreLoaded();
+
+      // Take the snapshot
+      final dataUrl = await _mapController!.takeWebSnapshot();
+
+      if (!mounted) return;
+
+      // Show the snapshot in a dialog
+      await _showSnapshotDialog(dataUrl);
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Failed to take snapshot: $e')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isCapturing = false);
+      }
+    }
+  }
+
+  /// Takes a snapshot with a custom map size
+  Future<void> _takeCustomSizeSnapshot(Size size) async {
+    if (_mapController == null || !kIsWeb) return;
+
+    setState(() => _isCapturing = true);
+
+    try {
+      // Define a custom size for the snapshot (e.g., 800x600)
+      setState(() => _customSize = size);
+
+      // Temporarily resize the map
+      final originalSize = await _mapController!.setWebMapToCustomSize(size);
+
+      // Wait for tiles to load at the new size
+      await _mapController!.waitUntilMapTilesAreLoaded();
+
+      // Take the snapshot
+      final dataUrl = await _mapController!.takeWebSnapshot();
+
+      // Restore the original size
+      await _mapController!.setWebMapToCustomSize(originalSize);
+
+      if (!mounted) return;
+
+      setState(() => _customSize = null);
+
+      // Show the snapshot in a dialog
+      await _showSnapshotDialog(dataUrl, size: size);
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Failed to take snapshot: $e')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isCapturing = false;
+          _customSize = null;
+        });
+      }
+    }
+  }
+
+  Future<void> _showSnapshotDialog(String dataUrl, {Size? size}) async {
+    // Parse the base64 data from the data URL
+    // Format: data:image/png;base64,<base64data>
+    final base64Data = dataUrl.split(',').last;
+    final imageBytes = base64Decode(base64Data);
+
+    await showDialog<void>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Row(
+          children: [
+            const Icon(Icons.camera_alt),
+            const SizedBox(width: 8),
+            Text(size != null
+                ? 'Snapshot (${size.width.toInt()}x${size.height.toInt()})'
+                : 'Map Snapshot'),
+          ],
+        ),
+        content: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxWidth: MediaQuery.of(context).size.width * 0.8,
+            maxHeight: MediaQuery.of(context).size.height * 0.6,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Flexible(
+                child: Container(
+                  decoration: BoxDecoration(
+                    border: Border.all(color: Colors.grey),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(8),
+                    child: Image.memory(
+                      imageBytes,
+                      fit: BoxFit.contain,
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              Text(
+                'Image size: ${(imageBytes.length / 1024).toStringAsFixed(1)} KB',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Close'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const isWeb = kIsWeb;
+
+    return Scaffold(
+      body: Stack(
+        children: [
+          MapLibreMap(
+            styleString: ExampleConstants.demoMapStyle,
+            onMapCreated: _onMapCreated,
+            onStyleLoadedCallback: _onStyleLoaded,
+            initialCameraPosition: ExampleConstants.londonCameraPosition,
+            trackCameraPosition: true,
+            compassEnabled: true,
+          ),
+          if (_isCapturing)
+            const ColoredBox(
+              color: Colors.black54,
+              child: Center(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    CircularProgressIndicator(),
+                    SizedBox(height: 16),
+                    Text(
+                      'Capturing snapshot...',
+                      style: TextStyle(color: Colors.white),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          if (_customSize != null)
+            Positioned(
+              top: 16,
+              left: 16,
+              child: Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Text(
+                    'Custom size: ${_customSize!.width.toInt()}x${_customSize!.height.toInt()}',
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+      bottomNavigationBar: !isWeb
+          ? Container(
+              padding: const EdgeInsets.all(16),
+              child: const Card(
+                child: Padding(
+                  padding: EdgeInsets.all(16),
+                  child: Text(
+                    'Map snapshots are only available on web platform.',
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              ),
+            )
+          : SafeArea(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  spacing: 16,
+                  children: [
+                    ExampleButton(
+                      label: 'Take Snapshot',
+                      icon: Icons.camera_alt,
+                      onPressed: _canInteractWithMap && !_isCapturing && isWeb
+                          ? _takeSnapshot
+                          : null,
+                      style: ExampleButtonStyle.filled,
+                    ),
+                    ExampleButton(
+                      label: 'Custom Size (800x600)',
+                      icon: Icons.crop,
+                      onPressed: _canInteractWithMap && !_isCapturing && isWeb
+                          ? () => _takeCustomSizeSnapshot(const Size(800, 600))
+                          : null,
+                      style: ExampleButtonStyle.tonal,
+                    ),
+                    ExampleButton(
+                      label: 'Custom Size (360x800)',
+                      icon: Icons.crop,
+                      onPressed: _canInteractWithMap && !_isCapturing && isWeb
+                          ? () => _takeCustomSizeSnapshot(const Size(360, 800))
+                          : null,
+                      style: ExampleButtonStyle.tonal,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+    );
+  }
+}

--- a/maplibre_gl_example/lib/main.dart
+++ b/maplibre_gl_example/lib/main.dart
@@ -37,6 +37,7 @@ import 'examples/layers/symbol_layer_example.dart';
 import 'examples/layers/various_sources.dart';
 
 // Advanced examples
+import 'examples/advanced/map_snapshot.dart';
 import 'examples/advanced/offline_regions.dart';
 import 'examples/advanced/pmtiles.dart';
 import 'examples/advanced/translucent_full_map.dart';
@@ -102,6 +103,7 @@ final List<ExamplePage> _allPages = <ExamplePage>[
   const VariousSources(),
 
   // Advanced
+  const MapSnapshotPage(),
   const PMTilesPage(),
   const OfflineRegionsPage(),
   const TranslucentFullMapPage(),

--- a/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
+++ b/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
@@ -239,7 +239,7 @@ abstract class MapLibrePlatform {
   Future<bool?> getLayerVisibility(String layerId);
 
   /// Sets the web map to a custom size for rendering.
-  /// Returns the actual size that was set.
+  /// Returns the previous/initial size of the web map before this change.
   Future<Size> setWebMapToCustomSize(Size size);
 
   /// Waits until the map is idle after camera movement.

--- a/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
+++ b/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
@@ -234,6 +234,24 @@ abstract class MapLibrePlatform {
 
   Future<void> setLayerVisibility(String layerId, bool visible);
 
+  /// Returns the visibility of a layer.
+  /// Returns true if visible, false if hidden, null if layer not found.
+  Future<bool?> getLayerVisibility(String layerId);
+
+  /// Sets the web map to a custom size for rendering.
+  /// Returns the actual size that was set.
+  Future<Size> setWebMapToCustomSize(Size size);
+
+  /// Waits until the map is idle after camera movement.
+  Future<void> waitUntilMapIsIdleAfterMovement();
+
+  /// Waits until all visible map tiles are loaded.
+  Future<void> waitUntilMapTilesAreLoaded();
+
+  /// Takes a screenshot of the web map.
+  /// Returns a base64-encoded PNG image string.
+  Future<String> takeWebSnapshot();
+
   /// Method to set style string
   /// A MapLibre GL style document defining the map's appearance.
   /// The style document specification is at [https://maplibre.org/maplibre-style-spec].

--- a/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
+++ b/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
@@ -903,6 +903,40 @@ class MapLibreMethodChannel extends MapLibrePlatform {
   }
 
   @override
+  Future<bool?> getLayerVisibility(String layerId) async {
+    try {
+      final result = await _channel.invokeMethod('layer#getVisibility', <String, dynamic>{
+        'layerId': layerId,
+      });
+      return result as bool?;
+    } on PlatformException catch (e) {
+      return Future.error(e);
+    }
+  }
+
+  @override
+  Future<Size> setWebMapToCustomSize(Size size) async {
+    // Not supported on native platforms, return the requested size
+    return size;
+  }
+
+  @override
+  Future<void> waitUntilMapIsIdleAfterMovement() async {
+    // On native platforms, this is a no-op as camera animations complete synchronously
+  }
+
+  @override
+  Future<void> waitUntilMapTilesAreLoaded() async {
+    // On native platforms, this is a no-op
+  }
+
+  @override
+  Future<String> takeWebSnapshot() async {
+    // Not supported on native platforms
+    throw UnsupportedError('takeWebSnapshot is only supported on web platform');
+  }
+
+  @override
   void forceResizeWebMap() {}
 
   @override

--- a/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
+++ b/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
@@ -905,7 +905,8 @@ class MapLibreMethodChannel extends MapLibrePlatform {
   @override
   Future<bool?> getLayerVisibility(String layerId) async {
     try {
-      final result = await _channel.invokeMethod('layer#getVisibility', <String, dynamic>{
+      final result =
+          await _channel.invokeMethod('layer#getVisibility', <String, dynamic>{
         'layerId': layerId,
       });
       return result as bool?;

--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -1440,7 +1440,7 @@ class MapLibreMapController extends MapLibrePlatform
     final completer = Completer<String>();
     _map.once('render', (_) {
       final canvas = _map.getCanvas();
-      final dataUrl = canvas.toDataUrl();
+      final dataUrl = canvas.toDataUrl('image/png');
       completer.complete(dataUrl);
     });
     _map.triggerRepaint();

--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -1387,4 +1387,63 @@ class MapLibreMapController extends MapLibrePlatform
     final sourceIds = _map.getSourceIds();
     return sourceIds;
   }
+
+  @override
+  Future<bool?> getLayerVisibility(String layerId) async {
+    final property = _map.getLayoutProperty(layerId, 'visibility');
+    if (property == null) return true;
+    if (property is String) return property == "visible";
+    return false;
+  }
+
+  @override
+  Future<void> waitUntilMapIsIdleAfterMovement() async {
+    final complete = Completer<void>();
+    _map.once('idle', (_) => complete.complete());
+    return complete.future;
+  }
+
+  @override
+  Future<void> waitUntilMapTilesAreLoaded() async {
+    final tilesLoadedCompleter = Completer<void>();
+    if (_map.areTilesLoaded()) {
+      tilesLoadedCompleter.complete();
+    } else {
+      _map.once('sourcedata', (_) {
+        tilesLoadedCompleter.complete();
+      });
+    }
+    await tilesLoadedCompleter.future;
+  }
+
+  @override
+  Future<ui.Size> setWebMapToCustomSize(ui.Size size) async {
+    final initialSize = ui.Size(
+      _map.getContainer().clientWidth.toDouble(),
+      _map.getContainer().clientHeight.toDouble(),
+    );
+
+    _map.getContainer().style.width = '${size.width}px';
+    _map.getContainer().style.height = '${size.height}px';
+    _map.resize();
+
+    await waitUntilMapIsIdleAfterMovement();
+    return initialSize;
+  }
+
+  @override
+  Future<String> takeWebSnapshot() async {
+    // "preserveDrawingBuffer" is set to false in the the WebGL context to get the best possible performance,
+    // therefore we cannot directly use the canvas.toDataURL() method to get a snapshot of the map because it would be blank then.
+    // That's the reason why we trigger a repaint and then directly catch the image data from the canvas during the rendering.
+
+    final completer = Completer<String>();
+    _map.once('render', (_) {
+      final canvas = _map.getCanvas();
+      final dataUrl = canvas.toDataUrl();
+      completer.complete(dataUrl);
+    });
+    _map.triggerRepaint();
+    return completer.future;
+  }
 }


### PR DESCRIPTION
This MR adds several utility features for querying layer state and capturing map output, primarily targeting web platform enhancements.

**Features**
- getLayerVisibility - Query the visibility state of a layer by ID
- takeWebSnapshot - Capture map screenshots on the web platform
- setWebMapToCustomSize - Set the web map to fixed dimensions (useful for exporting/printing)
- waitUntilMapTilesAreLoaded - Async helper to wait for all tiles to finish loading
- waitUntilMapIsIdleAfterMovement - Async helper to wait for camera to stabilize after movement

**Changes**
- Added methods to MapLibreMapController
- Added platform interface definitions in [maplibre_gl_platform_interface](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Added method channel implementations for native platforms
- Added web implementations in [maplibre_gl_web](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
**Use Cases**
- Map export/screenshot functionality
- Automated testing that requires stable map state
- Custom UI that needs to query layer visibility
- Embedding maps at specific sizes for reports or PDFs