### PR TITLE
fix(web): improved 'styleimagemissing' handling on web

### DIFF
--- a/maplibre_gl_example/lib/examples/basics/multi_style_switch.dart
+++ b/maplibre_gl_example/lib/examples/basics/multi_style_switch.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
-import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
 
 import '../../page.dart';
+import '../../shared/constants.dart';
 
 /// A page that demonstrates switching between multiple map styles in MapLibre GL.
 ///
@@ -36,7 +36,7 @@ class _MultiStyleSwitchBodyState extends State<_MultiStyleSwitchBody> {
   CameraPosition? _lastCamera;
 
   // Demo styles
-  static const String _remoteStyle = MapLibreStyles.demo;
+  static const String _remoteStyle = ExampleConstants.demoMapStyle;
   static const String _embeddedMinimalStyle =
       '{"version":8,"sources":{},"layers":[{"id":"background","type":"background","paint":{"background-color":"#90EE90"}}]}';
   static const String _assetStyle = 'assets/style.json';
@@ -54,12 +54,12 @@ class _MultiStyleSwitchBodyState extends State<_MultiStyleSwitchBody> {
     setState(() => _isSwitching = true);
 
     final entry = _styles[index];
-    log('Switching to style: ${entry.label}');
 
     try {
       await _controller!.setStyle(entry.styleString);
     } catch (e, st) {
-      log('Failed to set style ${entry.label}: $e', stackTrace: st);
+      print(
+          'MultiStyleSwitchPage: Failed to set style ${entry.label}: $e\n$st');
       // Fallback to remote style
       await _controller!.setStyle(_remoteStyle);
       _currentIndex = 0;

--- a/maplibre_gl_example/lib/examples/layers/circle_layer_example.dart
+++ b/maplibre_gl_example/lib/examples/layers/circle_layer_example.dart
@@ -1,4 +1,3 @@
-import 'dart:developer' as dev;
 import 'dart:math';
 
 import 'package:flutter/material.dart';
@@ -91,7 +90,7 @@ class _CircleLayerBodyState extends State<_CircleLayerBody> {
 
       setState(() {});
     } catch (e) {
-      dev.log('Error adding circle layer: $e');
+      print('CircleLayerExample: Error adding circle layer: $e');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Error adding circle layer: $e')),
@@ -142,7 +141,7 @@ class _CircleLayerBodyState extends State<_CircleLayerBody> {
         ),
       );
     } catch (e) {
-      dev.log('Error updating circle layer: $e');
+      print('CircleLayerExample: Error updating circle layer: $e');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Error updating circle layer: $e')),

--- a/maplibre_gl_example/lib/examples/layers/fill_layer_example.dart
+++ b/maplibre_gl_example/lib/examples/layers/fill_layer_example.dart
@@ -1,4 +1,3 @@
-import 'dart:developer' as dev;
 import 'dart:math';
 
 import 'package:flutter/material.dart';
@@ -67,9 +66,9 @@ class _FillLayerBodyState extends State<_FillLayerBody> {
         'marker-pattern',
         ExampleConstants.markerPatternPath,
       );
-      dev.log('Pattern images loaded successfully', name: 'FillLayerExample');
+      print('FillLayerExample: Pattern images loaded successfully');
     } catch (e) {
-      dev.log('Error loading pattern images: $e');
+      print('FillLayerExample:  Error loading pattern images: $e');
     }
   }
 
@@ -104,7 +103,7 @@ class _FillLayerBodyState extends State<_FillLayerBody> {
 
       setState(() {});
     } catch (e) {
-      dev.log('Error adding fill layer: $e');
+      print('FillLayerExample: Error adding fill layer: $e');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Error adding fill layer: $e')),
@@ -161,7 +160,7 @@ class _FillLayerBodyState extends State<_FillLayerBody> {
         ),
       );
     } catch (e) {
-      dev.log('Error updating fill layer: $e');
+      print('FillLayerExample: Error updating fill layer: $e');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Error updating fill layer: $e')),

--- a/maplibre_gl_example/lib/examples/layers/fill_layer_example.dart
+++ b/maplibre_gl_example/lib/examples/layers/fill_layer_example.dart
@@ -68,7 +68,7 @@ class _FillLayerBodyState extends State<_FillLayerBody> {
       );
       print('FillLayerExample: Pattern images loaded successfully');
     } catch (e) {
-      print('FillLayerExample:  Error loading pattern images: $e');
+      print('FillLayerExample: Error loading pattern images: $e');
     }
   }
 

--- a/maplibre_gl_example/lib/examples/layers/line_layer_example.dart
+++ b/maplibre_gl_example/lib/examples/layers/line_layer_example.dart
@@ -1,4 +1,3 @@
-import 'dart:developer' as dev;
 import 'dart:math';
 
 import 'package:flutter/material.dart';
@@ -83,7 +82,7 @@ class _LineLayerBodyState extends State<_LineLayerBody> {
         ExampleConstants.markerPatternPath,
       );
     } catch (e) {
-      dev.log('Error loading pattern images: $e');
+      print('LineLayerExample: Error loading pattern images: $e');
     }
   }
 
@@ -114,7 +113,7 @@ class _LineLayerBodyState extends State<_LineLayerBody> {
 
       setState(() {});
     } catch (e) {
-      dev.log('Error adding line layer: $e');
+      print('LineLayerExample: Error adding line layer: $e');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Error adding line layer: $e')),
@@ -176,7 +175,7 @@ class _LineLayerBodyState extends State<_LineLayerBody> {
         ),
       );
     } catch (e) {
-      dev.log('Error updating line layer: $e');
+      print('LineLayerExample: Error updating line layer: $e');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Error updating layer: $e')),
@@ -579,7 +578,6 @@ class _LineLayerBodyState extends State<_LineLayerBody> {
 
     // Only update if a selection was made (not cancelled)
     if (result != null && result is _LineDashStyle) {
-      dev.log('Selected dash style: ${result.label}');
       setState(() => _lineDasharray = result);
       await _updateLayer();
     }

--- a/maplibre_gl_example/lib/examples/layers/symbol_layer_example.dart
+++ b/maplibre_gl_example/lib/examples/layers/symbol_layer_example.dart
@@ -1,4 +1,3 @@
-import 'dart:developer' as dev;
 import 'dart:math';
 
 import 'package:flutter/material.dart';
@@ -129,7 +128,7 @@ class _SymbolLayerBodyState extends State<_SymbolLayerBody> {
 
       setState(() {});
     } catch (e) {
-      dev.log('Error adding symbol layer: $e');
+      print('SymbolLayerExample: Error adding symbol layer: $e');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Error adding symbol layer: $e')),
@@ -208,7 +207,7 @@ class _SymbolLayerBodyState extends State<_SymbolLayerBody> {
         ),
       );
     } catch (e) {
-      dev.log('Error updating symbol layer: $e');
+      print('SymbolLayerExample: Error updating symbol layer: $e');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Error updating symbol layer: $e')),

--- a/maplibre_gl_web/lib/maplibre_gl_web.dart
+++ b/maplibre_gl_web/lib/maplibre_gl_web.dart
@@ -2,7 +2,6 @@ library;
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:developer' as dev;
 
 import 'dart:js_interop';
 


### PR DESCRIPTION
Improved handling of the `stileimagemissing` callback from MapLibre web.
Removed `dev.log` in favor of the `print` method.

Closes and fixes #663.