### PR TITLE
feat: add featureTapsTriggersMapClick option to control map click call on feature taps

### DIFF
--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/Convert.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/Convert.java
@@ -321,5 +321,9 @@ static LocationEngineRequest toLocationEngineRequest(Object o) {
     if (translucentTextureSurface != null) {
       sink.setTranslucentTextureSurface(toBoolean(translucentTextureSurface));
     }
+    final Object ignoreFeatureTapOnMapClick = data.get("ignoreFeatureTapOnMapClick");
+    if (ignoreFeatureTapOnMapClick != null) {
+      sink.setIgnoreFeatureTapOnMapClick(toBoolean(ignoreFeatureTapOnMapClick));
+    }
   }
 }

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/Convert.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/Convert.java
@@ -321,9 +321,9 @@ static LocationEngineRequest toLocationEngineRequest(Object o) {
     if (translucentTextureSurface != null) {
       sink.setTranslucentTextureSurface(toBoolean(translucentTextureSurface));
     }
-    final Object ignoreFeatureTapOnMapClick = data.get("ignoreFeatureTapOnMapClick");
-    if (ignoreFeatureTapOnMapClick != null) {
-      sink.setIgnoreFeatureTapOnMapClick(toBoolean(ignoreFeatureTapOnMapClick));
+    final Object featureTapsTriggersMapClick = data.get("featureTapsTriggersMapClick");
+    if (featureTapsTriggersMapClick != null) {
+      sink.setFeatureTapsTriggersMapClick(toBoolean(featureTapsTriggersMapClick));
     }
   }
 }

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapBuilder.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapBuilder.java
@@ -20,6 +20,7 @@ class MapLibreMapBuilder implements MapLibreMapOptionsSink {
   private boolean trackCameraPosition = false;
   private boolean myLocationEnabled = false;
   private boolean dragEnabled = true;
+  private boolean featureTapsTriggersMapClick = false;
   private int myLocationTrackingMode = 0;
   private int myLocationRenderMode = 0;
   private String styleString = "";
@@ -34,7 +35,15 @@ class MapLibreMapBuilder implements MapLibreMapOptionsSink {
 
     final MapLibreMapController controller =
         new MapLibreMapController(
-            id, context, messenger, lifecycleProvider, options, styleString, dragEnabled);
+            id, 
+            context, 
+            messenger, 
+            lifecycleProvider, 
+            options, 
+            styleString, 
+            dragEnabled, 
+            featureTapsTriggersMapClick
+        );
     controller.init();
     controller.setMyLocationEnabled(myLocationEnabled);
     controller.setMyLocationTrackingMode(myLocationTrackingMode);
@@ -237,7 +246,7 @@ class MapLibreMapBuilder implements MapLibreMapOptionsSink {
   }
 
   public void setFeatureTapsTriggersMapClick(boolean triggers) {
-    options.featureTapsTriggersMapClick(triggers);
+    this.featureTapsTriggersMapClick = triggers;
   }
 
   @Override

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapBuilder.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapBuilder.java
@@ -236,6 +236,10 @@ class MapLibreMapBuilder implements MapLibreMapOptionsSink {
     this.dragEnabled = enabled;
   }
 
+  public void setFeatureTapsTriggersMapClick(boolean triggers) {
+    options.featureTapsTriggersMapClick(triggers);
+  }
+
   @Override
   public void setLocationEngineProperties(@NonNull LocationEngineRequest locationEngineRequest) {
     this.locationEngineRequest = locationEngineRequest;

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
@@ -140,7 +140,7 @@ final class MapLibreMapController
   private LocationEngineFactory myLocationEngineFactory = new LocationEngineFactory();
   private boolean disposed = false;
   private boolean dragEnabled = true;
-  private boolean ignoreFeatureTapOnMapClick = true;
+  private boolean featureTapsTriggersMapClick = false;
   private boolean mapViewStarted = false;
   private MethodChannel.Result mapReadyResult;
   private LocationComponent locationComponent = null;
@@ -1952,8 +1952,8 @@ final class MapLibreMapController
       arguments.put("layerId", featureLayerPair.second);
       arguments.put("id", featureLayerPair.first.id());
       methodChannel.invokeMethod("feature#onTap", arguments);
-      // Fire map#onMapClick only if ignoreFeatureTapOnMapClick is false
-      if (!ignoreFeatureTapOnMapClick) {
+      // Fire map#onMapClick only if featureTapsTriggersMapClick is true
+      if (featureTapsTriggersMapClick) {
         methodChannel.invokeMethod("map#onMapClick", arguments);
       }
     } else {
@@ -2378,8 +2378,8 @@ final class MapLibreMapController
   }
 
   @Override
-  public void setIgnoreFeatureTapOnMapClick(boolean ignore) {
-    this.ignoreFeatureTapOnMapClick = ignore;
+  public void setFeatureTapsTriggersMapClick(boolean triggers) {
+    this.featureTapsTriggersMapClick = triggers;
   }
 
   private void updateMyLocationEnabled() {

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
@@ -188,11 +188,14 @@ final class MapLibreMapController
       MapLibreMapsPlugin.LifecycleProvider lifecycleProvider,
       MapLibreMapOptions options,
       String styleStringInitial,
-      boolean dragEnabled) {
+      boolean dragEnabled,
+      boolean featureTapsTriggersMapClick
+  ) {
     MapLibreUtils.getMapLibre(context);
     this.id = id;
     this.context = context;
     this.dragEnabled = dragEnabled;
+    this.featureTapsTriggersMapClick = featureTapsTriggersMapClick;
     this.styleStringInitial = styleStringInitial;
     this.mapViewContainer = new FrameLayout(context);
     this.mapView = new MapView(context, options);

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
@@ -140,6 +140,7 @@ final class MapLibreMapController
   private LocationEngineFactory myLocationEngineFactory = new LocationEngineFactory();
   private boolean disposed = false;
   private boolean dragEnabled = true;
+  private boolean ignoreFeatureTapOnMapClick = true;
   private boolean mapViewStarted = false;
   private MethodChannel.Result mapReadyResult;
   private LocationComponent locationComponent = null;
@@ -1951,9 +1952,14 @@ final class MapLibreMapController
       arguments.put("layerId", featureLayerPair.second);
       arguments.put("id", featureLayerPair.first.id());
       methodChannel.invokeMethod("feature#onTap", arguments);
+      // Fire map#onMapClick only if ignoreFeatureTapOnMapClick is false
+      if (!ignoreFeatureTapOnMapClick) {
+        methodChannel.invokeMethod("map#onMapClick", arguments);
+      }
+    } else {
+      // Always fire map#onMapClick when no feature is tapped
+      methodChannel.invokeMethod("map#onMapClick", arguments);
     }
-    // Always fire map#onMapClick for all map clicks
-    methodChannel.invokeMethod("map#onMapClick", arguments);
     return true;
   }
 
@@ -2369,6 +2375,11 @@ final class MapLibreMapController
   public void setTranslucentTextureSurface(boolean translucentTextureSurface) {
     // translucentTextureSurface is only useful during initial map creation
     // not for runtime updates, so this is a no-op
+  }
+
+  @Override
+  public void setIgnoreFeatureTapOnMapClick(boolean ignore) {
+    this.ignoreFeatureTapOnMapClick = ignore;
   }
 
   private void updateMyLocationEnabled() {

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapOptionsSink.kt
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapOptionsSink.kt
@@ -53,4 +53,6 @@ internal interface MapLibreMapOptionsSink {
     fun setForegroundLoadColor(loadColor: Int)
 
     fun setTranslucentTextureSurface(translucentTextureSurface: Boolean)
+
+    fun setIgnoreFeatureTapOnMapClick(ignore: Boolean)
 }

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapOptionsSink.kt
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapOptionsSink.kt
@@ -54,5 +54,5 @@ internal interface MapLibreMapOptionsSink {
 
     fun setTranslucentTextureSurface(translucentTextureSurface: Boolean)
 
-    fun setIgnoreFeatureTapOnMapClick(ignore: Boolean)
+    fun setFeatureTapsTriggersMapClick(triggers: Boolean)
 }

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/Convert.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/Convert.swift
@@ -87,6 +87,9 @@ class Convert {
         {
             delegate.setAttributionButtonPosition(position: position)
         }
+        if let ignoreFeatureTapOnMapClick = options["ignoreFeatureTapOnMapClick"] as? Bool {
+            delegate.setIgnoreFeatureTapOnMapClick(ignore: ignoreFeatureTapOnMapClick)
+        }
     }
     
     class func parseLatLngBoundsPadding(_ cameraUpdate: [Any]) -> UIEdgeInsets? {

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/Convert.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/Convert.swift
@@ -87,8 +87,8 @@ class Convert {
         {
             delegate.setAttributionButtonPosition(position: position)
         }
-        if let ignoreFeatureTapOnMapClick = options["ignoreFeatureTapOnMapClick"] as? Bool {
-            delegate.setIgnoreFeatureTapOnMapClick(ignore: ignoreFeatureTapOnMapClick)
+        if let featureTapsTriggersMapClick = options["featureTapsTriggersMapClick"] as? Bool {
+            delegate.setFeatureTapsTriggersMapClick(triggers: featureTapsTriggersMapClick)
         }
     }
     

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
@@ -10,6 +10,7 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
     private var mapView: MLNMapView
     private var isMapReady = false
     private var dragEnabled = true
+    private var ignoreFeatureTapOnMapClick = true
     private var isFirstStyleLoad = true
     private var onStyleLoadedCalled = false
     private var mapReadyResult: FlutterResult?
@@ -1243,14 +1244,24 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
                         "lat": coordinate.latitude,
                         "layerId": result.layerId,
             ])
+            // Fire map#onMapClick only if ignoreFeatureTapOnMapClick is false
+            if !ignoreFeatureTapOnMapClick {
+                channel?.invokeMethod("map#onMapClick", arguments: [
+                    "x": point.x,
+                    "y": point.y,
+                    "lng": coordinate.longitude,
+                    "lat": coordinate.latitude,
+                ])
+            }
+        } else {
+            // Always fire map#onMapClick when no feature is tapped
+            channel?.invokeMethod("map#onMapClick", arguments: [
+                "x": point.x,
+                "y": point.y,
+                "lng": coordinate.longitude,
+                "lat": coordinate.latitude,
+            ])
         }
-        // Always fire map#onMapClick for all map clicks
-        channel?.invokeMethod("map#onMapClick", arguments: [
-            "x": point.x,
-            "y": point.y,
-            "lng": coordinate.longitude,
-            "lat": coordinate.latitude,
-        ])
     }
 
     fileprivate func invokeFeatureDrag(
@@ -2105,6 +2116,10 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
 
     func setAttributionButtonPosition(position: MLNOrnamentPosition) {
         mapView.attributionButtonPosition = position
+    }
+
+    func setIgnoreFeatureTapOnMapClick(ignore: Bool) {
+        ignoreFeatureTapOnMapClick = ignore
     }
 }
 

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
@@ -10,7 +10,7 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
     private var mapView: MLNMapView
     private var isMapReady = false
     private var dragEnabled = true
-    private var ignoreFeatureTapOnMapClick = true
+    private var featureTapsTriggersMapClick = false
     private var isFirstStyleLoad = true
     private var onStyleLoadedCalled = false
     private var mapReadyResult: FlutterResult?
@@ -1244,8 +1244,8 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
                         "lat": coordinate.latitude,
                         "layerId": result.layerId,
             ])
-            // Fire map#onMapClick only if ignoreFeatureTapOnMapClick is false
-            if !ignoreFeatureTapOnMapClick {
+            // Fire map#onMapClick only if featureTapsTriggersMapClick is true
+            if featureTapsTriggersMapClick {
                 channel?.invokeMethod("map#onMapClick", arguments: [
                     "x": point.x,
                     "y": point.y,
@@ -2118,8 +2118,8 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
         mapView.attributionButtonPosition = position
     }
 
-    func setIgnoreFeatureTapOnMapClick(ignore: Bool) {
-        ignoreFeatureTapOnMapClick = ignore
+    func setFeatureTapsTriggersMapClick(triggers: Bool) {
+        featureTapsTriggersMapClick = triggers
     }
 }
 

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapOptionsSink.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapOptionsSink.swift
@@ -20,5 +20,5 @@ protocol MapLibreMapOptionsSink {
     func setCompassViewMargins(x: Double, y: Double)
     func setAttributionButtonMargins(x: Double, y: Double)
     func setAttributionButtonPosition(position: MLNOrnamentPosition)
-    func setIgnoreFeatureTapOnMapClick(ignore: Bool)
+    func setFeatureTapsTriggersMapClick(triggers: Bool)
 }

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapOptionsSink.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapOptionsSink.swift
@@ -20,4 +20,5 @@ protocol MapLibreMapOptionsSink {
     func setCompassViewMargins(x: Double, y: Double)
     func setAttributionButtonMargins(x: Double, y: Double)
     func setAttributionButtonPosition(position: MLNOrnamentPosition)
+    func setIgnoreFeatureTapOnMapClick(ignore: Bool)
 }

--- a/maplibre_gl/lib/src/maplibre_map.dart
+++ b/maplibre_gl/lib/src/maplibre_map.dart
@@ -31,6 +31,7 @@ class MapLibreMap extends StatefulWidget {
     this.tiltGesturesEnabled = true,
     this.doubleClickZoomEnabled,
     this.dragEnabled = true,
+    this.ignoreFeatureTapOnMapClick = true,
     this.trackCameraPosition = false,
     this.myLocationEnabled = false,
     this.myLocationTrackingMode = MyLocationTrackingMode.none,
@@ -135,6 +136,13 @@ class MapLibreMap extends StatefulWidget {
   /// Disable to avoid performance issues that from the drag event listeners.
   /// Biggest impact in android
   final bool dragEnabled;
+
+  /// Whether to ignore feature tap events when the map is clicked.
+  /// Defaults to `true`.
+  ///
+  /// If `true`, `onMapClick` will not be called when the map is clicked
+  /// if there are features at the clicked location.
+  final bool ignoreFeatureTapOnMapClick;
 
   /// Geographical bounding box for the camera target.
   final CameraTargetBounds cameraTargetBounds;
@@ -431,7 +439,8 @@ class _MapLibreMapOptions {
       this.scaleControlUnit,
       this.locationEnginePlatforms,
       this.foregroundLoadColor,
-      this.translucentTextureSurface});
+      this.translucentTextureSurface,
+      this.ignoreFeatureTapOnMapClick});
 
   _MapLibreMapOptions.fromWidget(MapLibreMap map)
       : this(
@@ -462,6 +471,7 @@ class _MapLibreMapOptions {
           scaleControlUnit: map.scaleControlUnit,
           foregroundLoadColor: map.foregroundLoadColor,
           translucentTextureSurface: map.translucentTextureSurface,
+          ignoreFeatureTapOnMapClick: map.ignoreFeatureTapOnMapClick,
         );
 
   final bool? compassEnabled;
@@ -515,6 +525,8 @@ class _MapLibreMapOptions {
   final Color? foregroundLoadColor;
 
   final bool? translucentTextureSurface;
+
+  final bool? ignoreFeatureTapOnMapClick;
 
   final _gestureGroup = {
     'rotateGesturesEnabled',
@@ -570,6 +582,7 @@ class _MapLibreMapOptions {
     addIfNonNull('locationEngineProperties', locationEnginePlatforms?.toList());
     addIfNonNull('foregroundLoadColor', foregroundLoadColor?.toARGB32());
     addIfNonNull('translucentTextureSurface', translucentTextureSurface);
+    addIfNonNull('ignoreFeatureTapOnMapClick', ignoreFeatureTapOnMapClick);
     return optionsMap;
   }
 

--- a/maplibre_gl/lib/src/maplibre_map.dart
+++ b/maplibre_gl/lib/src/maplibre_map.dart
@@ -31,7 +31,7 @@ class MapLibreMap extends StatefulWidget {
     this.tiltGesturesEnabled = true,
     this.doubleClickZoomEnabled,
     this.dragEnabled = true,
-    this.ignoreFeatureTapOnMapClick = true,
+    this.featureTapsTriggersMapClick = false,
     this.trackCameraPosition = false,
     this.myLocationEnabled = false,
     this.myLocationTrackingMode = MyLocationTrackingMode.none,
@@ -137,12 +137,12 @@ class MapLibreMap extends StatefulWidget {
   /// Biggest impact in android
   final bool dragEnabled;
 
-  /// Whether to ignore feature tap events when the map is clicked.
-  /// Defaults to `true`.
+  /// Whether tapping on a feature also triggers the map click event.
+  /// Defaults to `false`.
   ///
-  /// If `true`, `onMapClick` will not be called when the map is clicked
-  /// if there are features at the clicked location.
-  final bool ignoreFeatureTapOnMapClick;
+  /// If `true`, both the feature tap and `onMapClick` events will fire when tapping a feature.
+  /// If `false`, only the feature tap event fires, and `onMapClick` is not called.
+  final bool featureTapsTriggersMapClick;
 
   /// Geographical bounding box for the camera target.
   final CameraTargetBounds cameraTargetBounds;
@@ -440,7 +440,7 @@ class _MapLibreMapOptions {
       this.locationEnginePlatforms,
       this.foregroundLoadColor,
       this.translucentTextureSurface,
-      this.ignoreFeatureTapOnMapClick});
+      this.featureTapsTriggersMapClick});
 
   _MapLibreMapOptions.fromWidget(MapLibreMap map)
       : this(
@@ -471,7 +471,7 @@ class _MapLibreMapOptions {
           scaleControlUnit: map.scaleControlUnit,
           foregroundLoadColor: map.foregroundLoadColor,
           translucentTextureSurface: map.translucentTextureSurface,
-          ignoreFeatureTapOnMapClick: map.ignoreFeatureTapOnMapClick,
+          featureTapsTriggersMapClick: map.featureTapsTriggersMapClick,
         );
 
   final bool? compassEnabled;
@@ -526,7 +526,7 @@ class _MapLibreMapOptions {
 
   final bool? translucentTextureSurface;
 
-  final bool? ignoreFeatureTapOnMapClick;
+  final bool? featureTapsTriggersMapClick;
 
   final _gestureGroup = {
     'rotateGesturesEnabled',
@@ -582,7 +582,7 @@ class _MapLibreMapOptions {
     addIfNonNull('locationEngineProperties', locationEnginePlatforms?.toList());
     addIfNonNull('foregroundLoadColor', foregroundLoadColor?.toARGB32());
     addIfNonNull('translucentTextureSurface', translucentTextureSurface);
-    addIfNonNull('ignoreFeatureTapOnMapClick', ignoreFeatureTapOnMapClick);
+    addIfNonNull('featureTapsTriggersMapClick', featureTapsTriggersMapClick);
     return optionsMap;
   }
 

--- a/maplibre_gl_example/lib/examples/annotations/annotations_example.dart
+++ b/maplibre_gl_example/lib/examples/annotations/annotations_example.dart
@@ -40,6 +40,10 @@ class _AnnotationsBodyState extends State<_AnnotationsBody> {
   String? _lastTappedAnnotation;
 
   void _onMapCreated(MapLibreMapController controller) {
+    controller.onFeatureTapped.add(
+      (point, coordinates, id, layerId, annotation) =>
+          print('AnnotationsExample: Feature tapped with id $id'),
+    );
     controller.onSymbolTapped.add(_onSymbolTapped);
     controller.onCircleTapped.add(_onCircleTapped);
     controller.onFillTapped.add(_onFillTapped);
@@ -424,6 +428,11 @@ class _AnnotationsBodyState extends State<_AnnotationsBody> {
           zoom: 8,
         ),
         trackCameraPosition: true,
+        // As true calls onMapClick also when annotations are tapped
+        featureTapsTriggersMapClick: true,
+        onMapClick: (point, coordinates) {
+          print('AnnotationsExample: Map clicked at $coordinates');
+        },
       ),
       controls: [
         InfoCard(

--- a/maplibre_gl_web/lib/src/convert.dart
+++ b/maplibre_gl_web/lib/src/convert.dart
@@ -103,6 +103,9 @@ class Convert {
       final unit = ScaleControlUnit.values[options['scaleControlUnit']];
       sink.setScaleControlUnit(unit);
     }
+    if (options.containsKey('ignoreFeatureTapOnMapClick')) {
+      sink.setIgnoreFeatureTapOnMapClick(options['ignoreFeatureTapOnMapClick']);
+    }
   }
 
   static CameraOptions toCameraOptions(

--- a/maplibre_gl_web/lib/src/convert.dart
+++ b/maplibre_gl_web/lib/src/convert.dart
@@ -103,8 +103,9 @@ class Convert {
       final unit = ScaleControlUnit.values[options['scaleControlUnit']];
       sink.setScaleControlUnit(unit);
     }
-    if (options.containsKey('ignoreFeatureTapOnMapClick')) {
-      sink.setIgnoreFeatureTapOnMapClick(options['ignoreFeatureTapOnMapClick']);
+    if (options.containsKey('featureTapsTriggersMapClick')) {
+      sink.setFeatureTapsTriggersMapClick(
+          options['featureTapsTriggersMapClick']);
     }
   }
 

--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -10,7 +10,7 @@ class MapLibreMapController extends MapLibrePlatform
   LatLng? _dragOrigin;
   LatLng? _dragPrevious;
   bool _dragEnabled = true;
-  bool _ignoreFeatureTapOnMapClick = true;
+  bool _featureTapsTriggersMapClick = false;
   final _addedFeaturesByLayer = <String, FeatureCollection>{};
   final _hoveredFeatureIdsByLayer = <String, List<dynamic>>{};
   Set<String>? _assetManifest;
@@ -631,8 +631,8 @@ class MapLibreMapController extends MapLibrePlatform
       payload['layerId'] = filtered.first.layerId;
       payload['id'] = filtered.first.id;
       onFeatureTappedPlatform(payload);
-      // Fire onMapClickPlatform only if ignoreFeatureTapOnMapClick is false
-      if (!_ignoreFeatureTapOnMapClick) {
+      // Fire onMapClickPlatform only if featureTapsTriggersMapClick is true
+      if (_featureTapsTriggersMapClick) {
         onMapClickPlatform(payload);
       }
     } else {
@@ -839,8 +839,8 @@ class MapLibreMapController extends MapLibrePlatform
   }
 
   @override
-  void setIgnoreFeatureTapOnMapClick(bool ignore) {
-    _ignoreFeatureTapOnMapClick = ignore;
+  void setFeatureTapsTriggersMapClick(bool triggers) {
+    _featureTapsTriggersMapClick = triggers;
   }
 
   void _addScaleControl({ScaleControlPosition? position}) {

--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -10,6 +10,7 @@ class MapLibreMapController extends MapLibrePlatform
   LatLng? _dragOrigin;
   LatLng? _dragPrevious;
   bool _dragEnabled = true;
+  bool _ignoreFeatureTapOnMapClick = true;
   final _addedFeaturesByLayer = <String, FeatureCollection>{};
   final _hoveredFeatureIdsByLayer = <String, List<dynamic>>{};
   Set<String>? _assetManifest;
@@ -630,10 +631,14 @@ class MapLibreMapController extends MapLibrePlatform
       payload['layerId'] = filtered.first.layerId;
       payload['id'] = filtered.first.id;
       onFeatureTappedPlatform(payload);
+      // Fire onMapClickPlatform only if ignoreFeatureTapOnMapClick is false
+      if (!_ignoreFeatureTapOnMapClick) {
+        onMapClickPlatform(payload);
+      }
+    } else {
+      // Always fire onMapClickPlatform when no feature is tapped
+      onMapClickPlatform(payload);
     }
-
-    // Always fire onMapClickPlatform for all map clicks
-    onMapClickPlatform(payload);
   }
 
   void _onMapLongClick(e) {
@@ -831,6 +836,11 @@ class MapLibreMapController extends MapLibrePlatform
       };
       _scaleControl!.setUnit(unitString);
     }
+  }
+
+  @override
+  void setIgnoreFeatureTapOnMapClick(bool ignore) {
+    _ignoreFeatureTapOnMapClick = ignore;
   }
 
   void _addScaleControl({ScaleControlPosition? position}) {

--- a/maplibre_gl_web/lib/src/options_sink.dart
+++ b/maplibre_gl_web/lib/src/options_sink.dart
@@ -44,4 +44,6 @@ abstract class MapLibreMapOptionsSink {
   void setScaleControlPosition(ScaleControlPosition position);
 
   void setScaleControlUnit(ScaleControlUnit unit);
+
+  void setIgnoreFeatureTapOnMapClick(bool ignore);
 }

--- a/maplibre_gl_web/lib/src/options_sink.dart
+++ b/maplibre_gl_web/lib/src/options_sink.dart
@@ -45,5 +45,5 @@ abstract class MapLibreMapOptionsSink {
 
   void setScaleControlUnit(ScaleControlUnit unit);
 
-  void setIgnoreFeatureTapOnMapClick(bool ignore);
+  void setFeatureTapsTriggersMapClick(bool triggers);
 }


### PR DESCRIPTION
Added `featureTapsTriggersMapClick` option to control whether tapping on a feature also triggers the `onMapClick` event. Defaults to `false` (feature taps don't trigger map clicks). When set to `true`, both the feature tap and map click events fire. Implemented across all platforms (Android, iOS, Web) through the map options.

Closes (again) #506 after a refactor.