### PR TITLE
Check source exists before adding

### DIFF
--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
@@ -409,6 +409,12 @@ final class MapLibreMapController
   }
 
   private void addGeoJsonSource(String sourceName, String source) {
+    // Check if source already exists to prevent CannotAddSourceException
+    // which can lead to native crashes
+    if (style.getSource(sourceName) != null) {
+      return;
+    }
+
     FeatureCollection featureCollection = FeatureCollection.fromJson(source);
 
     // Enable synchronous updates to reduce flicker during animations/dragging if dragEnabled option is true

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/SourcePropertyConverter.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/SourcePropertyConverter.java
@@ -200,6 +200,12 @@ class SourcePropertyConverter {
   }
 
   static void addSource(String id, Map<String, Object> properties, Style style) {
+    // Check if source already exists to prevent CannotAddSourceException
+    // which can lead to native crashes
+    if (style.getSource(id) != null) {
+      return;
+    }
+
     final Object type = properties.get("type");
     Source source = null;
 


### PR DESCRIPTION
Noticed during testing that android would crash if the same source was added multiple times.
On iOS it works fine and it turns out we check for and handle this case there.

So I did something similar for android.

**NOTES:**
See MapLibreMapController.swift lines:
- 1802
- 1887