### PR TITLE
Implements the `setMaximumFps` method for iOS platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## Unreleased
+
+### Added
+* iOS: Implemented `setMaximumFps` to control the preferred frame rate (#514).
+
 ## [0.25.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.24.1...v0.25.0) - 2026-01-07
 
 ### Added

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Added
+* iOS: Implemented `setMaximumFps` to control the preferred frame rate (#514).
+
 ## [0.25.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.24.1...v0.25.0) - 2026-01-07
 
 ### Added

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
@@ -301,6 +301,10 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
             let telemetryEnabled = UserDefaults.standard.bool(forKey: "MLNMapboxMetricsEnabled")
             result(telemetryEnabled)
         case "map#setMaximumFps":
+            guard let arguments = methodCall.arguments as? [String: Any] else { return }
+            if let fps = arguments["fps"] as? Int {
+                mapView.preferredFramesPerSecond = fps
+            }
             result(nil)
         case "map#forceOnlineMode":
             // Force online mode by ensuring network requests are enabled

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
@@ -303,7 +303,7 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
         case "map#setMaximumFps":
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
             if let fps = arguments["fps"] as? Int {
-                mapView.preferredFramesPerSecond = fps
+                mapView.preferredFramesPerSecond = MLNMapViewPreferredFramesPerSecond(rawValue: fps)
             }
             result(nil)
         case "map#forceOnlineMode":


### PR DESCRIPTION
  - Implements the `setMaximumFps` method for iOS platform                                                                                                                                                
  - Sets `mapView.preferredFramesPerSecond` based on the fps argument passed from Flutter                                                                                                                 
                                                                                                                                                                                                          
  This brings iOS to parity with Android for the `setMaximumFps` functionality.                                                                                                                           
                                                                                                                                                                                                                                                                                                                         
