### PR TITLE
chore(web): Migration to MapLibre GL JS v5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,9 @@ GeneratedPluginRegistrant.swift
 pubspec_overrides.yaml
 melos_overrides.yaml
 
-.fvm
-.fvmrc
 .ruby-version
 Gemfile*
+
+# FVM Version Cache
+.fvm/
+.fvmrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Added
 * iOS: Implemented `setMaximumFps` to control the preferred frame rate (#514).
 
+### Changed
+* Web: Upgraded MapLibre GL JS from 4.7.1 to 5.20.1 (#651).
+  * **Breaking (web)**: `initialCameraPosition` is now ignored if the map style contains camera properties (`center`, `zoom`, `bearing`, `pitch`). In MapLibre GL JS v5, style-defined camera values take priority over constructor options. To override the style's camera on web, call `jumpTo()` or `animateCamera()` after the map is loaded.
+  * Migrated `preserveDrawingBuffer`, `antialias`, and `failIfMajorPerformanceCaveat` from top-level `MapOptions` to `canvasContextAttributes` (v5 breaking change).
+  * Updated `on()`/`off()`/`once()` event methods to handle v5's `Subscription` return type instead of map instance.
+  * Removed obsolete `customAttribution` from `MapOptions` (now part of `AttributionControl` options in v5).
+
 ## [0.25.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.24.1...v0.25.0) - 2026-01-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Changed
 * Web: Upgraded MapLibre GL JS from 4.7.1 to 5.20.1 (#651).
-  * **Breaking (web)**: `initialCameraPosition` is now ignored if the map style contains camera properties (`center`, `zoom`, `bearing`, `pitch`). In MapLibre GL JS v5, style-defined camera values take priority over constructor options. To override the style's camera on web, call `jumpTo()` or `animateCamera()` after the map is loaded.
+  * **Breaking (web)**: `initialCameraPosition` is now ignored if the map style contains camera properties (`center`, `zoom`, `bearing`, `pitch`). In MapLibre GL JS v5, style-defined camera values take priority over constructor options. To override the style's camera on web, call `MapLibreMapController.moveCamera()` or `MapLibreMapController.animateCamera()` after the map is loaded.
   * Migrated `preserveDrawingBuffer`, `antialias`, and `failIfMajorPerformanceCaveat` from top-level `MapOptions` to `canvasContextAttributes` (v5 breaking change).
   * Updated `on()`/`off()`/`once()` event methods to handle v5's `Subscription` return type instead of map instance.
   * Removed obsolete `customAttribution` from `MapOptions` (now part of `AttributionControl` options in v5).

--- a/maplibre_gl/lib/src/maplibre_map.dart
+++ b/maplibre_gl/lib/src/maplibre_map.dart
@@ -113,6 +113,12 @@ class MapLibreMap extends StatefulWidget {
   final OnStyleLoadedCallback? onStyleLoadedCallback;
 
   /// The initial position of the map's camera.
+  ///
+  /// **Web note (MapLibre GL JS v5+):** If the map style contains camera
+  /// properties (`center`, `zoom`, `bearing`, `pitch`), the style values take
+  /// priority and this parameter is ignored. To override the style's camera on
+  /// web, call [MapLibreMapController.moveCamera] or
+  /// [MapLibreMapController.animateCamera] after the map is loaded.
   final CameraPosition initialCameraPosition;
 
   /// How long a user has to click the map **on iOS** until a long click is registered.

--- a/maplibre_gl_example/lib/examples/layers/edit_style_layer_animated.dart
+++ b/maplibre_gl_example/lib/examples/layers/edit_style_layer_animated.dart
@@ -241,6 +241,8 @@ class _EditStyleLayerAnimatedBodyState
 
     for (var i = 0; i < 30; i++) {
       final radius = 20 + 30 * sin(i * 0.2);
+      if (radius < 0) continue; // Skip negative radius values
+
       await _controller!.setLayerProperties(
         _circleLayerId,
         CircleLayerProperties(circleRadius: radius),
@@ -254,6 +256,8 @@ class _EditStyleLayerAnimatedBodyState
 
     for (var i = 0; i < 30; i++) {
       final width = 4 + 6 * sin(i * 0.2);
+      if (width < 0) continue; // Skip negative width values
+
       await _controller!.setLayerProperties(
         _lineLayerId,
         LineLayerProperties(lineWidth: width),
@@ -267,6 +271,7 @@ class _EditStyleLayerAnimatedBodyState
 
     for (var i = 0; i < 30; i++) {
       final opacity = 0.3 + 0.7 * sin(i * 0.2).abs();
+      if (opacity < 0) continue; // Skip negative opacity values
 
       await _controller!.setLayerProperties(
         _circleLayerId,
@@ -299,6 +304,14 @@ class _EditStyleLayerAnimatedBodyState
       final circleLng = center.longitude + 0.005 * sin(angle);
       final circleLat = center.latitude + 0.005 * cos(angle);
 
+      if (circleLat < -90 ||
+          circleLat > 90 ||
+          circleLng < -180 ||
+          circleLng > 180) {
+        // Skip invalid latitude values
+        continue;
+      }
+
       await _controller!.setGeoJsonSource(
         _circleSourceId,
         {
@@ -320,6 +333,15 @@ class _EditStyleLayerAnimatedBodyState
       for (var j = 0; j < 20; j++) {
         final x = -0.01 + (0.02 * j / 19);
         final y = 0.003 * sin(angle + j * 0.3);
+
+        // Skip invalid latitude values
+        if (center.latitude - 0.01 + y < -90 ||
+            center.latitude - 0.01 + y > 90) {
+          continue;
+        }
+        if (center.longitude + x < -180 || center.longitude + x > 180) {
+          continue;
+        }
         lineCoords.add([
           center.longitude + x,
           center.latitude - 0.01 + y,
@@ -344,6 +366,8 @@ class _EditStyleLayerAnimatedBodyState
 
       // Animate fill (rotate)
       final size = 0.005 + 0.002 * sin(angle);
+      if (size < 0) continue; // Skip negative size values
+
       await _controller!.setGeoJsonSource(
         _fillSourceId,
         {

--- a/maplibre_gl_example/lib/examples/layers/edit_style_layer_animated.dart
+++ b/maplibre_gl_example/lib/examples/layers/edit_style_layer_animated.dart
@@ -270,7 +270,6 @@ class _EditStyleLayerAnimatedBodyState
 
     for (var i = 0; i < 30; i++) {
       final opacity = 0.3 + 0.7 * sin(i * 0.2).abs();
-      if (opacity < 0) continue; // Skip negative opacity values
 
       await _controller!.setLayerProperties(
         _circleLayerId,
@@ -365,7 +364,6 @@ class _EditStyleLayerAnimatedBodyState
 
       // Animate fill (rotate)
       final size = 0.005 + 0.002 * sin(angle);
-      if (size < 0) continue; // Skip negative size values
 
       await _controller!.setGeoJsonSource(
         _fillSourceId,

--- a/maplibre_gl_example/web/index.html
+++ b/maplibre_gl_example/web/index.html
@@ -30,8 +30,8 @@
   <link rel="icon" type="image/png" href="favicon.png"/>
 
   <!-- MapLibre -->
-  <script src='https://unpkg.com/maplibre-gl@^4.7.1/dist/maplibre-gl.js'></script>
-  <link href='https://unpkg.com/maplibre-gl@^4.7.1/dist/maplibre-gl.css' rel='stylesheet'/>
+  <script src='https://unpkg.com/maplibre-gl@^5.20.1/dist/maplibre-gl.js'></script>
+  <link href='https://unpkg.com/maplibre-gl@^5.20.1/dist/maplibre-gl.css' rel='stylesheet'/>
   <script src="https://unpkg.com/pmtiles@3.2.0/dist/pmtiles.js"></script>
 
   <title>MapLibre Example</title>

--- a/maplibre_gl_web/CHANGELOG.md
+++ b/maplibre_gl_web/CHANGELOG.md
@@ -4,7 +4,7 @@ See top-level [CHANGELOG.md](../CHANGELOG.md) for full details.
 
 ### Changed
 * Upgraded MapLibre GL JS from 4.7.1 to 5.20.1 (#651)
-  * **Breaking**: `initialCameraPosition` is now ignored if the map style contains camera properties (`center`, `zoom`, `bearing`, `pitch`). MapLibre GL JS v5 gives priority to style-defined camera values over constructor options. Use `jumpTo()` or `animateCamera()` after map load to override.
+  * **Breaking**: `initialCameraPosition` is now ignored if the map style contains camera properties (`center`, `zoom`, `bearing`, `pitch`). MapLibre GL JS v5 gives priority to style-defined camera values over constructor options. Use `MapLibreMapController.moveCamera()` or `MapLibreMapController.animateCamera()` after map load to override.
   * `preserveDrawingBuffer`, `antialias`, `failIfMajorPerformanceCaveat` now set via `canvasContextAttributes` (MapLibre GL JS v5 API change)
   * `on()`/`off()`/`once()` adapted for v5 `Subscription` return type
   * Removed `customAttribution` from `MapOptionsJsImpl` (moved to `AttributionControl` options in v5)

--- a/maplibre_gl_web/CHANGELOG.md
+++ b/maplibre_gl_web/CHANGELOG.md
@@ -1,5 +1,14 @@
 See top-level [CHANGELOG.md](../CHANGELOG.md) for full details.
 
+## [0.26.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.25.0...v0.26.0)
+
+### Changed
+* Upgraded MapLibre GL JS from 4.7.1 to 5.20.1 (#651)
+  * **Breaking**: `initialCameraPosition` is now ignored if the map style contains camera properties (`center`, `zoom`, `bearing`, `pitch`). MapLibre GL JS v5 gives priority to style-defined camera values over constructor options. Use `jumpTo()` or `animateCamera()` after map load to override.
+  * `preserveDrawingBuffer`, `antialias`, `failIfMajorPerformanceCaveat` now set via `canvasContextAttributes` (MapLibre GL JS v5 API change)
+  * `on()`/`off()`/`once()` adapted for v5 `Subscription` return type
+  * Removed `customAttribution` from `MapOptionsJsImpl` (moved to `AttributionControl` options in v5)
+
 ## [0.25.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.24.1...v0.25.0) - 2026-01-07
 
 ### Major Changes

--- a/maplibre_gl_web/lib/src/interop/js.dart
+++ b/maplibre_gl_web/lib/src/interop/js.dart
@@ -39,13 +39,13 @@ void setJsProperty(JSObject obj, String propertyName, JSAny? value) {
   (obj as JSObjectExt)[propertyName] = value;
 }
 
-/// Creates an empty JavaScript object literal.
-@JS('Object.create')
-external JSObject _createJsObject(JSAny? prototype);
+/// Creates an empty JavaScript object literal equivalent to `{}`.
+@JS('Object')
+external JSObject _newJsObject();
 
 /// Helper function to create an empty JavaScript object.
 JSObject createJsObject() {
-  return _createJsObject(null);
+  return _newJsObject();
 }
 
 /// Parse a JSON string using JavaScript's native JSON.parse.

--- a/maplibre_gl_web/lib/src/interop/ui/map_interop.dart
+++ b/maplibre_gl_web/lib/src/interop/ui/map_interop.dart
@@ -965,6 +965,52 @@ extension MapLibreMapJsImplExtension on MapLibreMapJsImpl {
   external String get version;
 }
 
+/// WebGL context attributes for MapLibre GL JS v5+.
+///
+/// These options were previously top-level `MapOptions` properties
+/// (`preserveDrawingBuffer`, `antialias`, `failIfMajorPerformanceCaveat`).
+/// In v5 they are grouped under `canvasContextAttributes`.
+@JS()
+@staticInterop
+class CanvasContextAttributesJsImpl {
+  factory CanvasContextAttributesJsImpl() =>
+      createJsObject() as CanvasContextAttributesJsImpl;
+}
+
+extension CanvasContextAttributesJsImplExtension
+    on CanvasContextAttributesJsImpl {
+  /// If `true`, the map's canvas can be exported to a PNG using
+  /// `map.getCanvas().toDataURL()`. Defaults to `false`.
+  external JSBoolean? get preserveDrawingBuffer;
+  external set preserveDrawingBuffer(JSBoolean? value);
+
+  /// If `true`, the GL context will be created with MSAA antialiasing,
+  /// which can be useful for antialiasing custom layers. Defaults to `false`.
+  external JSBoolean? get antialias;
+  external set antialias(JSBoolean? value);
+
+  /// If `true`, map creation will fail if the performance of MapLibre GL JS
+  /// would be dramatically worse than expected (i.e. a software renderer
+  /// would be used). Defaults to `false`.
+  external JSBoolean? get failIfMajorPerformanceCaveat;
+  external set failIfMajorPerformanceCaveat(JSBoolean? value);
+
+  /// The WebGL context type to request. Defaults to `'webgl2withfallback'`.
+  /// Accepted values: `'webgl2'`, `'webgl'`, `'webgl2withfallback'`.
+  external JSString? get contextType;
+  external set contextType(JSString? value);
+
+  /// Hint to the browser about the preferred GPU power profile.
+  /// Defaults to `'high-performance'`.
+  external JSString? get powerPreference;
+  external set powerPreference(JSString? value);
+
+  /// If `true`, the drawing buffer is not cleared after rendering,
+  /// enabling off-screen composition. Defaults to `false`.
+  external JSBoolean? get desynchronized;
+  external set desynchronized(JSBoolean? value);
+}
+
 @JS()
 @staticInterop
 class MapOptionsJsImpl {
@@ -1008,27 +1054,15 @@ extension MapOptionsJsImplExtension on MapOptionsJsImpl {
   external JSBoolean get attributionControl;
   external set attributionControl(JSBoolean value);
 
-  /// String or strings to show in an {@link AttributionControl}. Only applicable if `options.attributionControl` is `true`.
-  /// `String` or `List<String>`
-  external JSAny get customAttribution;
-  external set customAttribution(JSAny value);
-
   /// A string representing the position of the MapLibre wordmark on the map. Valid options are `top-left`,`top-right`, `bottom-left`, `bottom-right`.
   external JSString get logoPosition;
   external set logoPosition(JSString value);
 
-  /// If `true`, map creation will fail if the performance of MapLibre
-  /// GL JS would be dramatically worse than expected (i.e. a software renderer would be used).
-  external JSBoolean get failIfMajorPerformanceCaveat;
-  external set failIfMajorPerformanceCaveat(JSBoolean value);
-
-  /// If `true`, the map's canvas can be exported to a PNG using `map.getCanvas().toDataURL()`. This is `false` by default as a performance optimization.
-  external JSBoolean get preserveDrawingBuffer;
-  external set preserveDrawingBuffer(JSBoolean value);
-
-  /// If `true`, the gl context will be created with MSAA antialiasing, which can be useful for antialiasing custom layers. this is `false` by default as a performance optimization.
-  external JSBoolean get antialias;
-  external set antialias(JSBoolean value);
+  /// WebGL context attributes to pass to the canvas. In MapLibre GL JS v5+,
+  /// `preserveDrawingBuffer`, `antialias`, and `failIfMajorPerformanceCaveat`
+  /// are configured here instead of as top-level MapOptions.
+  external CanvasContextAttributesJsImpl? get canvasContextAttributes;
+  external set canvasContextAttributes(CanvasContextAttributesJsImpl? value);
 
   /// If `false`, the map won't attempt to re-request tiles once they expire per their HTTP `cacheControl`/`expires` headers.
   external JSBoolean get refreshExpiredTiles;

--- a/maplibre_gl_web/lib/src/interop/util/evented_interop.dart
+++ b/maplibre_gl_web/lib/src/interop/util/evented_interop.dart
@@ -4,9 +4,19 @@ library;
 import 'dart:js_interop';
 import 'package:maplibre_gl_web/src/interop/geo/lng_lat_interop.dart';
 import 'package:maplibre_gl_web/src/interop/geo/point_interop.dart';
-import 'package:maplibre_gl_web/src/interop/ui/map_interop.dart';
-
 typedef ListenerJsImpl = JSFunction;
+
+/// A subscription returned by `on()` / `once()` in MapLibre GL JS v5+.
+/// Call [unsubscribe] to remove the listener without needing the original
+/// function reference.
+@JS()
+@staticInterop
+class SubscriptionJsImpl {}
+
+extension SubscriptionJsImplExtension on SubscriptionJsImpl {
+  /// Removes the event listener associated with this subscription.
+  external void unsubscribe();
+}
 
 @JS()
 @staticInterop
@@ -41,16 +51,16 @@ extension EventedJsImplExtension on EventedJsImpl {
   ///  @param {Function} listener The function to be called when the event is fired.
   ///    The listener function is called with the data object passed to `fire`,
   ///    extended with `target` and `type` properties.
-  ///  @returns {Object} `this`
-  external MapLibreMapJsImpl on(String type,
+  ///  @returns {Subscription} A subscription that can be used to unsubscribe.
+  external SubscriptionJsImpl on(String type,
       [JSAny? layerIdOrListener, ListenerJsImpl? listener]);
 
   ///  Removes a previously registered event listener.
   ///
   ///  @param {string} type The event type to remove listeners for.
   ///  @param {Function} listener The listener function to remove.
-  ///  @returns {Object} `this`
-  external MapLibreMapJsImpl off(String type,
+  ///  @returns {Subscription} A subscription that can be used to unsubscribe.
+  external SubscriptionJsImpl off(String type,
       [JSAny? layerIdOrListener, ListenerJsImpl? listener]);
 
   ///  Adds a listener that will be called only once to a specified event type.
@@ -59,8 +69,8 @@ extension EventedJsImplExtension on EventedJsImpl {
   ///
   ///  @param {string} type The event type to listen for.
   ///  @param {Function} listener The function to be called when the event is fired the first time.
-  ///  @returns {Object} `this`
-  external MapLibreMapJsImpl once(String type, ListenerJsImpl listener);
+  ///  @returns {Subscription} A subscription that can be used to unsubscribe.
+  external SubscriptionJsImpl once(String type, ListenerJsImpl listener);
 
   external void fire(EventJsImpl event, [JSAny? properties]);
 

--- a/maplibre_gl_web/lib/src/interop/util/evented_interop.dart
+++ b/maplibre_gl_web/lib/src/interop/util/evented_interop.dart
@@ -4,6 +4,7 @@ library;
 import 'dart:js_interop';
 import 'package:maplibre_gl_web/src/interop/geo/lng_lat_interop.dart';
 import 'package:maplibre_gl_web/src/interop/geo/point_interop.dart';
+
 typedef ListenerJsImpl = JSFunction;
 
 /// A subscription returned by `on()` / `once()` in MapLibre GL JS v5+.
@@ -52,16 +53,22 @@ extension EventedJsImplExtension on EventedJsImpl {
   ///    The listener function is called with the data object passed to `fire`,
   ///    extended with `target` and `type` properties.
   ///  @returns {Subscription} A subscription that can be used to unsubscribe.
-  external SubscriptionJsImpl on(String type,
-      [JSAny? layerIdOrListener, ListenerJsImpl? listener]);
+  external SubscriptionJsImpl on(
+    String type, [
+    JSAny? layerIdOrListener,
+    ListenerJsImpl? listener,
+  ]);
 
   ///  Removes a previously registered event listener.
   ///
   ///  @param {string} type The event type to remove listeners for.
   ///  @param {Function} listener The listener function to remove.
   ///  @returns {Subscription} A subscription that can be used to unsubscribe.
-  external SubscriptionJsImpl off(String type,
-      [JSAny? layerIdOrListener, ListenerJsImpl? listener]);
+  external SubscriptionJsImpl off(
+    String type, [
+    JSAny? layerIdOrListener,
+    ListenerJsImpl? listener,
+  ]);
 
   ///  Adds a listener that will be called only once to a specified event type.
   ///

--- a/maplibre_gl_web/lib/src/ui/map.dart
+++ b/maplibre_gl_web/lib/src/ui/map.dart
@@ -1122,23 +1122,13 @@ class MapOptions extends JsObjectWrapper<MapOptionsJsImpl> {
   /// If `true`, an {@link AttributionControl} will be added to the map.
   bool get attributionControl => jsObject.attributionControl.toDart;
 
-  /// String or strings to show in an {@link AttributionControl}. Only applicable if `options.attributionControl` is `true`.
-  /// `String` or `List<String>`
-  dynamic get customAttribution => jsObject.customAttribution;
-
   /// A string representing the position of the MapLibre wordmark on the map. Valid options are `top-left`,`top-right`, `bottom-left`, `bottom-right`.
   String get logoPosition => jsObject.logoPosition.toDart;
 
-  /// If `true`, map creation will fail if the performance of MapLibre
-  /// GL JS would be dramatically worse than expected (i.e. a software renderer would be used).
-  bool get failIfMajorPerformanceCaveat =>
-      jsObject.failIfMajorPerformanceCaveat.toDart;
-
-  /// If `true`, the map's canvas can be exported to a PNG using `map.getCanvas().toDataURL()`. This is `false` by default as a performance optimization.
-  bool get preserveDrawingBuffer => jsObject.preserveDrawingBuffer.toDart;
-
-  /// If `true`, the gl context will be created with MSAA antialiasing, which can be useful for antialiasing custom layers. this is `false` by default as a performance optimization.
-  bool get antialias => jsObject.antialias.toDart;
+  /// WebGL context attributes including `preserveDrawingBuffer`, `antialias`,
+  /// and `failIfMajorPerformanceCaveat`. In MapLibre GL JS v5+, these are
+  /// configured via `canvasContextAttributes` instead of top-level options.
+  dynamic get canvasContextAttributes => jsObject.canvasContextAttributes;
 
   /// If `false`, the map won't attempt to re-request tiles once they expire per their HTTP `cacheControl`/`expires` headers.
   bool get refreshExpiredTiles => jsObject.refreshExpiredTiles.toDart;
@@ -1250,7 +1240,6 @@ class MapOptions extends JsObjectWrapper<MapOptionsJsImpl> {
     bool? pitchWithRotate,
     num? clickTolerance,
     bool? attributionControl,
-    dynamic customAttribution,
     String? logoPosition,
     bool? failIfMajorPerformanceCaveat,
     bool? preserveDrawingBuffer,
@@ -1298,17 +1287,24 @@ class MapOptions extends JsObjectWrapper<MapOptionsJsImpl> {
     jsImpl.pitchWithRotate = (pitchWithRotate ?? true).toJS;
     if (clickTolerance != null) jsImpl.clickTolerance = clickTolerance.toJS;
     jsImpl.attributionControl = (attributionControl ?? true).toJS;
-    if (customAttribution != null) {
-      jsImpl.customAttribution = customAttribution.toJS;
-    }
     jsImpl.logoPosition = (logoPosition ?? 'bottom-left').toJS;
-    if (failIfMajorPerformanceCaveat != null) {
-      jsImpl.failIfMajorPerformanceCaveat = failIfMajorPerformanceCaveat.toJS;
+    // In MapLibre GL JS v5+, WebGL context options moved into canvasContextAttributes
+    if (preserveDrawingBuffer != null ||
+        antialias != null ||
+        failIfMajorPerformanceCaveat != null) {
+      final canvasAttrs = CanvasContextAttributesJsImpl();
+      if (preserveDrawingBuffer != null) {
+        canvasAttrs.preserveDrawingBuffer = preserveDrawingBuffer.toJS;
+      }
+      if (antialias != null) {
+        canvasAttrs.antialias = antialias.toJS;
+      }
+      if (failIfMajorPerformanceCaveat != null) {
+        canvasAttrs.failIfMajorPerformanceCaveat =
+            failIfMajorPerformanceCaveat.toJS;
+      }
+      jsImpl.canvasContextAttributes = canvasAttrs;
     }
-    if (preserveDrawingBuffer != null) {
-      jsImpl.preserveDrawingBuffer = preserveDrawingBuffer.toJS;
-    }
-    if (antialias != null) jsImpl.antialias = antialias.toJS;
     if (refreshExpiredTiles != null) {
       jsImpl.refreshExpiredTiles = refreshExpiredTiles.toJS;
     }

--- a/maplibre_gl_web/lib/src/ui/map.dart
+++ b/maplibre_gl_web/lib/src/ui/map.dart
@@ -1128,7 +1128,8 @@ class MapOptions extends JsObjectWrapper<MapOptionsJsImpl> {
   /// WebGL context attributes including `preserveDrawingBuffer`, `antialias`,
   /// and `failIfMajorPerformanceCaveat`. In MapLibre GL JS v5+, these are
   /// configured via `canvasContextAttributes` instead of top-level options.
-  dynamic get canvasContextAttributes => jsObject.canvasContextAttributes;
+  CanvasContextAttributesJsImpl? get canvasContextAttributes =>
+      jsObject.canvasContextAttributes;
 
   /// If `false`, the map won't attempt to re-request tiles once they expire per their HTTP `cacheControl`/`expires` headers.
   bool get refreshExpiredTiles => jsObject.refreshExpiredTiles.toDart;

--- a/maplibre_gl_web/lib/src/util/evented.dart
+++ b/maplibre_gl_web/lib/src/util/evented.dart
@@ -13,10 +13,17 @@ typedef LayerEventListener = dynamic Function(Event object, String layerId);
 /// Dart wrapper around MapLibre GL JS v5+ Subscription object.
 /// Allows unsubscribing from events without storing the listener reference.
 class Subscription extends JsObjectWrapper<SubscriptionJsImpl> {
-  /// Removes the event listener associated with this subscription.
-  void unsubscribe() => jsObject.unsubscribe();
+  final void Function()? _onUnsubscribe;
 
-  Subscription.fromJsObject(super.jsObject) : super.fromJsObject();
+  /// Removes the event listener associated with this subscription.
+  void unsubscribe() {
+    jsObject.unsubscribe();
+    _onUnsubscribe?.call();
+  }
+
+  Subscription.fromJsObject(super.jsObject, {void Function()? onUnsubscribe})
+      : _onUnsubscribe = onUnsubscribe,
+        super.fromJsObject();
 }
 
 class Event extends JsObjectWrapper<EventJsImpl> {
@@ -68,8 +75,6 @@ class Evented extends JsObjectWrapper<EventedJsImpl> {
   /// Key is a composite of (eventType, layerIdOrListener.hashCode?, listener.hashCode)
   final _listeners = <String, JSFunction>{};
 
-  /// Store subscriptions so they can be used for unsubscribe.
-  final _subscriptions = <String, Subscription>{};
 
   /// Build a composite key (eventType::layerId::listenerHashCode).
   String _listenerKey(
@@ -120,8 +125,9 @@ class Evented extends JsObjectWrapper<EventedJsImpl> {
 
     final key = _listenerKey(type, layerIdOrListener, listener);
     _listeners[key] = jsFn;
-    final subscription = Subscription.fromJsObject(sub);
-    _subscriptions[key] = subscription;
+    final subscription = Subscription.fromJsObject(sub, onUnsubscribe: () {
+      _listeners.remove(key);
+    });
 
     return subscription;
   }
@@ -137,7 +143,6 @@ class Evented extends JsObjectWrapper<EventedJsImpl> {
   ]) {
     final key = _listenerKey(type, layerIdOrListener, listener);
     final jsFn = _listeners.remove(key);
-    _subscriptions.remove(key);
 
     if (layerIdOrListener is Listener || layerIdOrListener is GeoListener) {
       jsObject.off(type, jsFn);

--- a/maplibre_gl_web/lib/src/util/evented.dart
+++ b/maplibre_gl_web/lib/src/util/evented.dart
@@ -5,11 +5,19 @@ import 'package:maplibre_gl_web/src/geo/lng_lat.dart';
 import 'package:maplibre_gl_web/src/geo/point.dart';
 import 'package:maplibre_gl_web/src/interop/interop.dart';
 import 'package:maplibre_gl_web/src/ui/control/geolocate_control.dart';
-import 'package:maplibre_gl_web/src/ui/map.dart';
 
 typedef Listener = dynamic Function(Event object);
 typedef GeoListener = dynamic Function(dynamic object);
 typedef LayerEventListener = dynamic Function(Event object, String layerId);
+
+/// Dart wrapper around MapLibre GL JS v5+ Subscription object.
+/// Allows unsubscribing from events without storing the listener reference.
+class Subscription extends JsObjectWrapper<SubscriptionJsImpl> {
+  /// Removes the event listener associated with this subscription.
+  void unsubscribe() => jsObject.unsubscribe();
+
+  Subscription.fromJsObject(super.jsObject) : super.fromJsObject();
+}
 
 class Event extends JsObjectWrapper<EventJsImpl> {
   String get id => jsObject.id;
@@ -58,6 +66,9 @@ class Evented extends JsObjectWrapper<EventedJsImpl> {
   /// Key is a composite of (eventType, layerIdOrListener.hashCode?, listener.hashCode)
   final _listeners = <String, JSFunction>{};
 
+  /// Store subscriptions so they can be used for unsubscribe.
+  final _subscriptions = <String, Subscription>{};
+
   /// Build a composite key (eventType::layerId::listenerHashCode).
   String _listenerKey(
       String type, dynamic layerIdOrListener, LayerEventListener? listener) {
@@ -70,21 +81,21 @@ class Evented extends JsObjectWrapper<EventedJsImpl> {
   ///  @param {Function} listener The function to be called when the event is fired.
   ///    The listener function is called with the data object passed to `fire`,
   ///    extended with `target` and `type` properties.
-  ///  @returns {Object} `this`
-  MapLibreMap on(String type,
+  ///  @returns {Subscription} A subscription that can be used to unsubscribe.
+  Subscription on(String type,
       [dynamic layerIdOrListener, LayerEventListener? listener]) {
     final JSFunction jsFn;
-    final MapLibreMapJsImpl mapJsImpl;
+    final SubscriptionJsImpl sub;
     if (this is GeolocateControl && layerIdOrListener is GeoListener) {
       jsFn = ((JSAny position) {
         layerIdOrListener(position);
       }).toJS;
-      mapJsImpl = jsObject.on(type, jsFn);
+      sub = jsObject.on(type, jsFn);
     } else if (layerIdOrListener is Listener) {
       jsFn = ((EventJsImpl object) {
         layerIdOrListener(Event.fromJsObject(object));
       }).toJS;
-      mapJsImpl = jsObject.on(type, jsFn);
+      sub = jsObject.on(type, jsFn);
     } else {
       jsFn = ((EventJsImpl object) {
         listener!(Event.fromJsObject(object), layerIdOrListener);
@@ -92,34 +103,35 @@ class Evented extends JsObjectWrapper<EventedJsImpl> {
       final layerId = layerIdOrListener is String
           ? layerIdOrListener.toJS
           : layerIdOrListener.toString().toJS;
-      mapJsImpl = jsObject.on(type, layerId, jsFn);
+      sub = jsObject.on(type, layerId, jsFn);
     }
 
-    _listeners[_listenerKey(type, layerIdOrListener, listener)] = jsFn;
+    final key = _listenerKey(type, layerIdOrListener, listener);
+    _listeners[key] = jsFn;
+    final subscription = Subscription.fromJsObject(sub);
+    _subscriptions[key] = subscription;
 
-    return MapLibreMap.fromJsObject(mapJsImpl);
+    return subscription;
   }
 
   ///  Removes a previously registered event listener.
   ///
   ///  @param {string} type The event type to remove listeners for.
   ///  @param {Function} listener The listener function to remove.
-  ///  @returns {Object} `this`
-  MapLibreMap off(String type,
+  void off(String type,
       [dynamic layerIdOrListener, LayerEventListener? listener]) {
     final key = _listenerKey(type, layerIdOrListener, listener);
     final jsFn = _listeners.remove(key);
-    final MapLibreMapJsImpl mapJsImpl;
+    _subscriptions.remove(key);
 
     if (layerIdOrListener is Listener || layerIdOrListener is GeoListener) {
-      mapJsImpl = jsObject.off(type, jsFn);
+      jsObject.off(type, jsFn);
     } else {
       final layerId = layerIdOrListener is String
           ? layerIdOrListener.toJS
           : layerIdOrListener.toString().toJS;
-      mapJsImpl = jsObject.off(type, layerId, jsFn);
+      jsObject.off(type, layerId, jsFn);
     }
-    return MapLibreMap.fromJsObject(mapJsImpl);
   }
 
   ///  Adds a listener that will be called only once to a specified event type.
@@ -128,13 +140,15 @@ class Evented extends JsObjectWrapper<EventedJsImpl> {
   ///
   ///  @param {string} type The event type to listen for.
   ///  @param {Function} listener The function to be called when the event is fired the first time.
-  ///  @returns {Object} `this`
-  MapLibreMap once(String type, Listener listener) =>
-      MapLibreMap.fromJsObject(jsObject.once(
-          type,
-          ((EventJsImpl object) {
-            listener(Event.fromJsObject(object));
-          }).toJS));
+  ///  @returns {Subscription} A subscription that can be used to unsubscribe.
+  Subscription once(String type, Listener listener) {
+    final sub = jsObject.once(
+        type,
+        ((EventJsImpl object) {
+          listener(Event.fromJsObject(object));
+        }).toJS);
+    return Subscription.fromJsObject(sub);
+  }
 
   fire(Event event, [JSAny? properties]) =>
       jsObject.fire(event.jsObject, properties);

--- a/maplibre_gl_web/lib/src/util/evented.dart
+++ b/maplibre_gl_web/lib/src/util/evented.dart
@@ -87,27 +87,34 @@ class Evented extends JsObjectWrapper<EventedJsImpl> {
   ///    The listener function is called with the data object passed to `fire`,
   ///    extended with `target` and `type` properties.
   ///  @returns {Subscription} A subscription that can be used to unsubscribe.
-  Subscription on(String type,
-      [dynamic layerIdOrListener, LayerEventListener? listener]) {
+  Subscription on(
+    String type, [
+    dynamic layerIdOrListener,
+    LayerEventListener? listener,
+  ]) {
     final JSFunction jsFn;
     final SubscriptionJsImpl sub;
     if (this is GeolocateControl && layerIdOrListener is GeoListener) {
-      jsFn = ((JSAny position) {
-        layerIdOrListener(position);
-      }).toJS;
+      jsFn =
+          ((JSAny position) {
+            layerIdOrListener(position);
+          }).toJS;
       sub = jsObject.on(type, jsFn);
     } else if (layerIdOrListener is Listener) {
-      jsFn = ((EventJsImpl object) {
-        layerIdOrListener(Event.fromJsObject(object));
-      }).toJS;
+      jsFn =
+          ((EventJsImpl object) {
+            layerIdOrListener(Event.fromJsObject(object));
+          }).toJS;
       sub = jsObject.on(type, jsFn);
     } else {
-      jsFn = ((EventJsImpl object) {
-        listener!(Event.fromJsObject(object), layerIdOrListener);
-      }).toJS;
-      final layerId = layerIdOrListener is String
-          ? layerIdOrListener.toJS
-          : layerIdOrListener.toString().toJS;
+      jsFn =
+          ((EventJsImpl object) {
+            listener!(Event.fromJsObject(object), layerIdOrListener);
+          }).toJS;
+      final layerId =
+          layerIdOrListener is String
+              ? layerIdOrListener.toJS
+              : layerIdOrListener.toString().toJS;
       sub = jsObject.on(type, layerId, jsFn);
     }
 
@@ -123,8 +130,11 @@ class Evented extends JsObjectWrapper<EventedJsImpl> {
   ///
   ///  @param {string} type The event type to remove listeners for.
   ///  @param {Function} listener The listener function to remove.
-  void off(String type,
-      [dynamic layerIdOrListener, LayerEventListener? listener]) {
+  void off(
+    String type, [
+    dynamic layerIdOrListener,
+    LayerEventListener? listener,
+  ]) {
     final key = _listenerKey(type, layerIdOrListener, listener);
     final jsFn = _listeners.remove(key);
     _subscriptions.remove(key);
@@ -132,9 +142,10 @@ class Evented extends JsObjectWrapper<EventedJsImpl> {
     if (layerIdOrListener is Listener || layerIdOrListener is GeoListener) {
       jsObject.off(type, jsFn);
     } else {
-      final layerId = layerIdOrListener is String
-          ? layerIdOrListener.toJS
-          : layerIdOrListener.toString().toJS;
+      final layerId =
+          layerIdOrListener is String
+              ? layerIdOrListener.toJS
+              : layerIdOrListener.toString().toJS;
       jsObject.off(type, layerId, jsFn);
     }
   }
@@ -148,10 +159,11 @@ class Evented extends JsObjectWrapper<EventedJsImpl> {
   ///  @returns {Subscription} A subscription that can be used to unsubscribe.
   Subscription once(String type, Listener listener) {
     final sub = jsObject.once(
-        type,
-        ((EventJsImpl object) {
-          listener(Event.fromJsObject(object));
-        }).toJS);
+      type,
+      ((EventJsImpl object) {
+        listener(Event.fromJsObject(object));
+      }).toJS,
+    );
     return Subscription.fromJsObject(sub);
   }
 

--- a/maplibre_gl_web/lib/src/util/evented.dart
+++ b/maplibre_gl_web/lib/src/util/evented.dart
@@ -22,8 +22,8 @@ class Subscription extends JsObjectWrapper<SubscriptionJsImpl> {
   }
 
   Subscription.fromJsObject(super.jsObject, {void Function()? onUnsubscribe})
-      : _onUnsubscribe = onUnsubscribe,
-        super.fromJsObject();
+    : _onUnsubscribe = onUnsubscribe,
+      super.fromJsObject();
 }
 
 class Event extends JsObjectWrapper<EventJsImpl> {
@@ -75,7 +75,6 @@ class Evented extends JsObjectWrapper<EventedJsImpl> {
   /// Key is a composite of (eventType, layerIdOrListener.hashCode?, listener.hashCode)
   final _listeners = <String, JSFunction>{};
 
-
   /// Build a composite key (eventType::layerId::listenerHashCode).
   String _listenerKey(
     String type,
@@ -125,9 +124,12 @@ class Evented extends JsObjectWrapper<EventedJsImpl> {
 
     final key = _listenerKey(type, layerIdOrListener, listener);
     _listeners[key] = jsFn;
-    final subscription = Subscription.fromJsObject(sub, onUnsubscribe: () {
-      _listeners.remove(key);
-    });
+    final subscription = Subscription.fromJsObject(
+      sub,
+      onUnsubscribe: () {
+        _listeners.remove(key);
+      },
+    );
 
     return subscription;
   }

--- a/maplibre_gl_web/lib/src/utils.dart
+++ b/maplibre_gl_web/lib/src/utils.dart
@@ -75,9 +75,11 @@ JSAny? jsify(Object? dartObject) {
 }
 
 /// Converts a Dart Map to a JavaScript object.
+/// Null values are omitted to avoid MapLibre GL JS style validation errors.
 JSObject jsifyMap(Map<String, dynamic> map) {
   final jsObj = createJsObject();
   map.forEach((key, value) {
+    if (value == null) return;
     final jsValue = jsify(value);
     setJsProperty(jsObj, key, jsValue);
   });


### PR DESCRIPTION
## Summary
- Upgrade MapLibre GL JS from v4.7.1 to v5.20.1
- Migrate event system to use the new `Subscription` class returned by `on()`/`once()`/`off()` instead of returning the map instance
- Move WebGL context options (`preserveDrawingBuffer`, `antialias`, `failIfMajorPerformanceCaveat`) into `canvasContextAttributes` per v5 API
- Remove deprecated `customAttribution` top-level option from `MapOptions`
- Update `jsifyMap` to omit null values for compatibility with v5 style validation
- Improve `dartify` to handle `JSAny` primitive types (`JSBoolean`, `JSNumber`, `JSString`)
- Fix `initialCameraPosition` handling to align with v5 breaking changes
- Update example app `index.html` to load v5 SDK and use modern Flutter web bootstrap

Closes #651 
