### PR TITLE
feat: Enhance GeoJSON source handling with type checks and error logging

### DIFF
--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
@@ -408,6 +408,20 @@ final class MapLibreMapController
     methodChannel.invokeMethod("map#onUserLocationUpdated", arguments);
   }
 
+  private FeatureCollection parseGeoJsonToFeatureCollection(String geojson) {
+    JsonElement jsonElement = JsonParser.parseString(geojson);
+    String type = jsonElement.getAsJsonObject().get("type").getAsString();
+
+    if ("FeatureCollection".equals(type)) {
+      return FeatureCollection.fromJson(geojson);
+    } else if ("Feature".equals(type)) {
+      Feature feature = Feature.fromJson(geojson);
+      return FeatureCollection.fromFeatures(new Feature[]{ feature });
+    }
+
+    return null;
+  }
+
   private void addGeoJsonSource(String sourceName, String source) {
     if (style == null || !style.isFullyLoaded()) {
       Log.w(TAG, "addGeoJsonSource: style not ready, skipping");
@@ -421,17 +435,9 @@ final class MapLibreMapController
     }
 
     try {
-      FeatureCollection featureCollection;
-      JsonElement jsonElement = JsonParser.parseString(source);
-      String type = jsonElement.getAsJsonObject().get("type").getAsString();
-
-      if ("FeatureCollection".equals(type)) {
-        featureCollection = FeatureCollection.fromJson(source);
-      } else if ("Feature".equals(type)) {
-        Feature feature = Feature.fromJson(source);
-        featureCollection = FeatureCollection.fromFeatures(new Feature[]{ feature });
-      } else {
-        Log.w(TAG, "addGeoJsonSource: unsupported GeoJSON type '" + type + "', skipping");
+      FeatureCollection featureCollection = parseGeoJsonToFeatureCollection(source);
+      if (featureCollection == null) {
+        Log.w(TAG, "addGeoJsonSource: unsupported GeoJSON type, skipping");
         return;
       }
 
@@ -452,17 +458,9 @@ final class MapLibreMapController
     }
 
     try {
-      FeatureCollection featureCollection;
-      JsonElement jsonElement = JsonParser.parseString(geojson);
-      String type = jsonElement.getAsJsonObject().get("type").getAsString();
-
-      if ("FeatureCollection".equals(type)) {
-        featureCollection = FeatureCollection.fromJson(geojson);
-      } else if ("Feature".equals(type)) {
-        Feature feature = Feature.fromJson(geojson);
-        featureCollection = FeatureCollection.fromFeatures(Collections.singletonList(feature));
-      } else {
-        Log.w(TAG, "setGeoJsonSource: unsupported GeoJSON type '" + type + "', skipping update");
+      FeatureCollection featureCollection = parseGeoJsonToFeatureCollection(geojson);
+      if (featureCollection == null) {
+        Log.w(TAG, "setGeoJsonSource: unsupported GeoJSON type, skipping update");
         return;
       }
 

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
@@ -409,20 +409,40 @@ final class MapLibreMapController
   }
 
   private void addGeoJsonSource(String sourceName, String source) {
+    if (style == null || !style.isFullyLoaded()) {
+      Log.w(TAG, "addGeoJsonSource: style not ready, skipping");
+      return;
+    }
+
     // Check if source already exists to prevent CannotAddSourceException
     // which can lead to native crashes
     if (style.getSource(sourceName) != null) {
       return;
     }
 
-    FeatureCollection featureCollection = FeatureCollection.fromJson(source);
+    try {
+      FeatureCollection featureCollection;
+      JsonElement jsonElement = JsonParser.parseString(source);
+      String type = jsonElement.getAsJsonObject().get("type").getAsString();
 
-    // Enable synchronous updates to reduce flicker during animations/dragging if dragEnabled option is true
-    GeoJsonOptions options = new GeoJsonOptions().withSynchronousUpdate(dragEnabled);
-    GeoJsonSource geoJsonSource = new GeoJsonSource(sourceName, featureCollection, options);
-    addedFeaturesByLayer.put(sourceName, featureCollection);
+      if ("FeatureCollection".equals(type)) {
+        featureCollection = FeatureCollection.fromJson(source);
+      } else if ("Feature".equals(type)) {
+        Feature feature = Feature.fromJson(source);
+        featureCollection = FeatureCollection.fromFeatures(new Feature[]{ feature });
+      } else {
+        Log.w(TAG, "addGeoJsonSource: unsupported GeoJSON type '" + type + "', skipping");
+        return;
+      }
 
-    style.addSource(geoJsonSource);
+      GeoJsonOptions options = new GeoJsonOptions().withSynchronousUpdate(dragEnabled);
+      GeoJsonSource geoJsonSource = new GeoJsonSource(sourceName, featureCollection, options);
+      addedFeaturesByLayer.put(sourceName, featureCollection);
+
+      style.addSource(geoJsonSource);
+    } catch (Exception e) {
+      Log.e(TAG, "addGeoJsonSource: error adding source '" + sourceName + "'", e);
+    }
   }
 
   private void setGeoJsonSource(String sourceName, String geojson) {
@@ -430,12 +450,33 @@ final class MapLibreMapController
       Log.w(TAG, "setGeoJsonSource: style not ready, skipping update");
       return;
     }
-    
-    FeatureCollection featureCollection = FeatureCollection.fromJson(geojson);
-    GeoJsonSource geoJsonSource = style.getSourceAs(sourceName);
-    addedFeaturesByLayer.put(sourceName, featureCollection);
 
-    geoJsonSource.setGeoJson(featureCollection);
+    try {
+      FeatureCollection featureCollection;
+      JsonElement jsonElement = JsonParser.parseString(geojson);
+      String type = jsonElement.getAsJsonObject().get("type").getAsString();
+
+      if ("FeatureCollection".equals(type)) {
+        featureCollection = FeatureCollection.fromJson(geojson);
+      } else if ("Feature".equals(type)) {
+        Feature feature = Feature.fromJson(geojson);
+        featureCollection = FeatureCollection.fromFeatures(Collections.singletonList(feature));
+      } else {
+        Log.w(TAG, "setGeoJsonSource: unsupported GeoJSON type '" + type + "', skipping update");
+        return;
+      }
+
+      GeoJsonSource geoJsonSource = style.getSourceAs(sourceName);
+      if (geoJsonSource == null) {
+        Log.w(TAG, "setGeoJsonSource: source '" + sourceName + "' not found, skipping update");
+        return;
+      }
+
+      addedFeaturesByLayer.put(sourceName, featureCollection);
+      geoJsonSource.setGeoJson(featureCollection);
+    } catch (Exception e) {
+      Log.e(TAG, "setGeoJsonSource: error updating source '" + sourceName + "'", e);
+    }
   }
 
   private void setGeoJsonFeature(String sourceName, String geojsonFeature) {
@@ -443,22 +484,29 @@ final class MapLibreMapController
       Log.w(TAG, "setGeoJsonFeature: style not ready, skipping update");
       return;
     }
-    
-    Feature feature = Feature.fromJson(geojsonFeature);
-    FeatureCollection featureCollection = addedFeaturesByLayer.get(sourceName);
-    GeoJsonSource geoJsonSource = style.getSourceAs(sourceName);
-    if (featureCollection != null && geoJsonSource != null) {
-      final List<Feature> features = featureCollection.features();
-      for (int i = 0; i < features.size(); i++) {
-        final String id = features.get(i).id();
-        if (id.equals(feature.id())) {
-          features.set(i, feature);
-          break;
-        }
-      }
 
-      // Synchronous updates are enabled via GeoJsonOptions at source creation when dragEnabled is true
-      geoJsonSource.setGeoJson(featureCollection);
+    try {
+      Feature feature = Feature.fromJson(geojsonFeature);
+      FeatureCollection featureCollection = addedFeaturesByLayer.get(sourceName);
+      GeoJsonSource geoJsonSource = style.getSourceAs(sourceName);
+
+      if (featureCollection != null && geoJsonSource != null) {
+        final String featureId = feature.id();
+        final List<Feature> features = featureCollection.features();
+        
+        if (featureId != null && features != null) {
+          for (int i = 0; i < features.size(); i++) {
+            if (featureId.equals(features.get(i).id())) {
+              features.set(i, feature);
+              break;
+            }
+          }
+        }
+
+        geoJsonSource.setGeoJson(featureCollection);
+      }
+    } catch (Exception e) {
+      Log.e(TAG, "setGeoJsonFeature: error updating feature in source '" + sourceName + "'", e);
     }
   }
 
@@ -1047,7 +1095,9 @@ final class MapLibreMapController
                   source.setGeoJson((String)call.argument("data"));
                   ret = true;
                 }
-              } catch (Exception e) {}
+              } catch (Exception e) {
+                Log.e(TAG, "editGeoJsonSource: error updating source '" + call.argument("id") + "'", e);
+              }
             }
           }
           Map<String, Boolean> reply = new HashMap<>();
@@ -1067,7 +1117,9 @@ final class MapLibreMapController
                   source.setUrl((String)call.argument("url"));
                   ret = true;
                 }
-              } catch (Exception e) {}
+              } catch (Exception e) {
+                Log.e(TAG, "editGeoJsonUrl: error updating source '" + call.argument("id") + "'", e);
+              }
             }
           }
           Map<String, Boolean> reply = new HashMap<>();


### PR DESCRIPTION
## Summary
- Closes #760   
- Fix setGeoJsonSource() crash (SIGSEGV) when passing a single Feature instead of a FeatureCollection
- Add null checks and try-catch to addGeoJsonSource, setGeoJsonSource, setGeoJsonFeature, editGeoJsonSource, and editGeoJsonUrl
- Automatically wrap single Feature GeoJSON into a FeatureCollection in both addGeoJsonSource and setGeoJsonSource