### PR TITLE
feat: Introduce unit test

### DIFF
--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -55,9 +55,8 @@ jobs:
         if: always()
         uses: codecov/codecov-action@v5
         with:
-          files: |
-            maplibre_gl_platform_interface/coverage/lcov.info,
-            maplibre_gl/coverage/lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: maplibre_gl_platform_interface/coverage/lcov.info,maplibre_gl/coverage/lcov.info
 
   test-web:
     name: "Run web tests"

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -51,13 +51,12 @@ jobs:
         with:
           run-bootstrap: true
       - run: melos run test:io:coverage --no-select
-      - name: Upload coverage
+      - name: Upload coverage to Codecov
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: codecov/codecov-action@v5
         with:
-          name: coverage-reports
-          path: |
-            maplibre_gl_platform_interface/coverage/lcov.info
+          files: |
+            maplibre_gl_platform_interface/coverage/lcov.info,
             maplibre_gl/coverage/lcov.info
 
   test-web:

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -50,7 +50,15 @@ jobs:
       - uses: bluefireteam/melos-action@v3
         with:
           run-bootstrap: true
-      - run: melos run test:io
+      - run: melos run test:io:coverage --no-select
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-reports
+          path: |
+            maplibre_gl_platform_interface/coverage/lcov.info
+            maplibre_gl/coverage/lcov.info
 
   test-web:
     name: "Run web tests"
@@ -64,7 +72,7 @@ jobs:
       - uses: bluefireteam/melos-action@v3
         with:
           run-bootstrap: true
-      - run: melos run test:web
+      - run: melos run test:web --no-select
 
   code-gen:
     name: "Generate code from templates"

--- a/maplibre_gl/pubspec.yaml
+++ b/maplibre_gl/pubspec.yaml
@@ -16,6 +16,8 @@ dependencies:
   maplibre_gl_web: ^0.25.0
 
 dev_dependencies:
+  flutter_test:
+    sdk: flutter
   very_good_analysis: ^10.0.0
 
 flutter:

--- a/maplibre_gl/test/annotation_manager_test.dart
+++ b/maplibre_gl/test/annotation_manager_test.dart
@@ -1,0 +1,424 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_gl/maplibre_gl.dart';
+
+import 'helpers/fake_platform.dart';
+
+/// Creates a [MapLibreMapController] backed by the given [FakeMapLibrePlatform]
+/// with all annotation types enabled for interaction, and manually initializes
+/// all annotation managers (bypassing the async style-loaded callback).
+Future<MapLibreMapController> _createController(
+  FakeMapLibrePlatform platform,
+) async {
+  final controller = MapLibreMapController(
+    maplibrePlatform: platform,
+    initialCameraPosition: const CameraPosition(target: LatLng(0, 0)),
+    annotationOrder: AnnotationType.values,
+    annotationConsumeTapEvents: AnnotationType.values,
+  );
+
+  // Manually initialize managers (the style-loaded callback is async and
+  // cannot be awaited through ArgumentCallbacks.call).
+  controller.fillManager = FillManager(controller);
+  await controller.fillManager!.initialize();
+  controller.lineManager = LineManager(controller);
+  await controller.lineManager!.initialize();
+  controller.circleManager = CircleManager(controller);
+  await controller.circleManager!.initialize();
+  controller.symbolManager = SymbolManager(controller);
+  await controller.symbolManager!.initialize();
+
+  return controller;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FakeMapLibrePlatform platform;
+  late MapLibreMapController controller;
+
+  setUp(() async {
+    platform = FakeMapLibrePlatform();
+    controller = await _createController(platform);
+    platform.reset();
+  });
+
+  group('CircleManager', () {
+    test('add creates a circle and calls setGeoJsonSource', () async {
+      final circle = await controller.addCircle(
+        const CircleOptions(geometry: LatLng(10, 20)),
+      );
+
+      expect(circle, isA<Circle>());
+      expect(circle.options.geometry, const LatLng(10, 20));
+      expect(controller.circles, contains(circle));
+    });
+
+    test('addCircles creates multiple circles', () async {
+      final circles = await controller.addCircles([
+        const CircleOptions(geometry: LatLng(1, 2)),
+        const CircleOptions(geometry: LatLng(3, 4)),
+      ]);
+
+      expect(circles.length, 2);
+      expect(controller.circles.length, 2);
+    });
+
+    test('removeCircle removes from the set', () async {
+      final circle = await controller.addCircle(
+        const CircleOptions(geometry: LatLng(10, 20)),
+      );
+      await controller.removeCircle(circle);
+
+      expect(controller.circles, isEmpty);
+    });
+
+    test('removeCircles removes multiple', () async {
+      final circles = await controller.addCircles([
+        const CircleOptions(geometry: LatLng(1, 2)),
+        const CircleOptions(geometry: LatLng(3, 4)),
+      ]);
+      await controller.removeCircles(circles);
+
+      expect(controller.circles, isEmpty);
+    });
+
+    test('clearCircles removes all circles', () async {
+      await controller.addCircles([
+        const CircleOptions(geometry: LatLng(1, 2)),
+        const CircleOptions(geometry: LatLng(3, 4)),
+      ]);
+      await controller.clearCircles();
+
+      expect(controller.circles, isEmpty);
+    });
+
+    test('updateCircle updates circle options', () async {
+      final circle = await controller.addCircle(
+        const CircleOptions(geometry: LatLng(10, 20)),
+      );
+      await controller.updateCircle(
+        circle,
+        const CircleOptions(circleRadius: 15.0),
+      );
+
+      final updated = controller.circles.first;
+      expect(updated.options.circleRadius, 15.0);
+    });
+  });
+
+  group('LineManager', () {
+    test('add creates a line', () async {
+      final line = await controller.addLine(
+        const LineOptions(
+          geometry: [LatLng(0, 0), LatLng(1, 1)],
+        ),
+      );
+
+      expect(line, isA<Line>());
+      expect(controller.lines, contains(line));
+    });
+
+    test('addLines creates multiple lines', () async {
+      final lines = await controller.addLines([
+        const LineOptions(geometry: [LatLng(0, 0), LatLng(1, 1)]),
+        const LineOptions(geometry: [LatLng(2, 2), LatLng(3, 3)]),
+      ]);
+
+      expect(lines.length, 2);
+      expect(controller.lines.length, 2);
+    });
+
+    test('removeLine removes from the set', () async {
+      final line = await controller.addLine(
+        const LineOptions(geometry: [LatLng(0, 0), LatLng(1, 1)]),
+      );
+      await controller.removeLine(line);
+
+      expect(controller.lines, isEmpty);
+    });
+
+    test('clearLines removes all lines', () async {
+      await controller.addLines([
+        const LineOptions(geometry: [LatLng(0, 0), LatLng(1, 1)]),
+        const LineOptions(geometry: [LatLng(2, 2), LatLng(3, 3)]),
+      ]);
+      await controller.clearLines();
+
+      expect(controller.lines, isEmpty);
+    });
+
+    test('line with pattern goes to second layer bucket', () async {
+      platform.reset();
+      await controller.addLine(
+        const LineOptions(
+          geometry: [LatLng(0, 0), LatLng(1, 1)],
+          linePattern: 'pattern-image',
+        ),
+      );
+
+      // The selectLayer function should route pattern lines to layer index 1
+      expect(platform.wasCalled('setGeoJsonSource'), isTrue);
+    });
+  });
+
+  group('FillManager', () {
+    test('add creates a fill', () async {
+      final fill = await controller.addFill(
+        const FillOptions(
+          geometry: [
+            [LatLng(0, 0), LatLng(1, 0), LatLng(1, 1), LatLng(0, 0)],
+          ],
+        ),
+      );
+
+      expect(fill, isA<Fill>());
+      expect(controller.fills, contains(fill));
+    });
+
+    test('addFills creates multiple fills', () async {
+      final fills = await controller.addFills([
+        const FillOptions(
+          geometry: [
+            [LatLng(0, 0), LatLng(1, 0), LatLng(1, 1), LatLng(0, 0)],
+          ],
+        ),
+        const FillOptions(
+          geometry: [
+            [LatLng(2, 2), LatLng(3, 2), LatLng(3, 3), LatLng(2, 2)],
+          ],
+        ),
+      ]);
+
+      expect(fills.length, 2);
+      expect(controller.fills.length, 2);
+    });
+
+    test('removeFill removes from the set', () async {
+      final fill = await controller.addFill(
+        const FillOptions(
+          geometry: [
+            [LatLng(0, 0), LatLng(1, 0), LatLng(1, 1), LatLng(0, 0)],
+          ],
+        ),
+      );
+      await controller.removeFill(fill);
+
+      expect(controller.fills, isEmpty);
+    });
+
+    test('clearFills removes all fills', () async {
+      await controller.addFills([
+        const FillOptions(
+          geometry: [
+            [LatLng(0, 0), LatLng(1, 0), LatLng(1, 1), LatLng(0, 0)],
+          ],
+        ),
+        const FillOptions(
+          geometry: [
+            [LatLng(2, 2), LatLng(3, 2), LatLng(3, 3), LatLng(2, 2)],
+          ],
+        ),
+      ]);
+      await controller.clearFills();
+
+      expect(controller.fills, isEmpty);
+    });
+
+    test('fill with pattern goes to second layer bucket', () async {
+      platform.reset();
+      await controller.addFill(
+        const FillOptions(
+          geometry: [
+            [LatLng(0, 0), LatLng(1, 0), LatLng(1, 1), LatLng(0, 0)],
+          ],
+          fillPattern: 'pattern-image',
+        ),
+      );
+
+      expect(platform.wasCalled('setGeoJsonSource'), isTrue);
+    });
+  });
+
+  group('SymbolManager', () {
+    test('add creates a symbol', () async {
+      final symbol = await controller.addSymbol(
+        const SymbolOptions(geometry: LatLng(10, 20)),
+      );
+
+      expect(symbol, isA<Symbol>());
+      expect(controller.symbols, contains(symbol));
+    });
+
+    test('addSymbols creates multiple symbols', () async {
+      final symbols = await controller.addSymbols([
+        const SymbolOptions(geometry: LatLng(1, 2)),
+        const SymbolOptions(geometry: LatLng(3, 4)),
+      ]);
+
+      expect(symbols.length, 2);
+      expect(controller.symbols.length, 2);
+    });
+
+    test('removeSymbol removes from the set', () async {
+      final symbol = await controller.addSymbol(
+        const SymbolOptions(geometry: LatLng(10, 20)),
+      );
+      await controller.removeSymbol(symbol);
+
+      expect(controller.symbols, isEmpty);
+    });
+
+    test('clearSymbols removes all symbols', () async {
+      await controller.addSymbols([
+        const SymbolOptions(geometry: LatLng(1, 2)),
+        const SymbolOptions(geometry: LatLng(3, 4)),
+      ]);
+      await controller.clearSymbols();
+
+      expect(controller.symbols, isEmpty);
+    });
+  });
+
+  group('AnnotationManager initialization', () {
+    test('managers are initialized', () {
+      expect(controller.circleManager, isNotNull);
+      expect(controller.circleManager!.isInitialized, isTrue);
+      expect(controller.lineManager, isNotNull);
+      expect(controller.lineManager!.isInitialized, isTrue);
+      expect(controller.fillManager, isNotNull);
+      expect(controller.fillManager!.isInitialized, isTrue);
+      expect(controller.symbolManager, isNotNull);
+      expect(controller.symbolManager!.isInitialized, isTrue);
+    });
+
+    test('layer counts per manager type', () {
+      expect(controller.circleManager!.layerIds.length, 1);
+      expect(controller.lineManager!.layerIds.length, 2);
+      expect(controller.fillManager!.layerIds.length, 2);
+      expect(controller.symbolManager!.layerIds.length, 1);
+    });
+
+    test('adding annotation before init throws', () {
+      final freshPlatform = FakeMapLibrePlatform();
+      final freshController = MapLibreMapController(
+        maplibrePlatform: freshPlatform,
+        initialCameraPosition: const CameraPosition(target: LatLng(0, 0)),
+        annotationOrder: AnnotationType.values,
+        annotationConsumeTapEvents: AnnotationType.values,
+      );
+
+      expect(
+        () => freshController.addCircle(
+          const CircleOptions(geometry: LatLng(0, 0)),
+        ),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+
+  group('AnnotationManager GeoJSON output', () {
+    test('setGeoJsonSource is called with FeatureCollection on add', () async {
+      platform.reset();
+      await controller.addCircle(
+        const CircleOptions(geometry: LatLng(10, 20)),
+      );
+
+      final calls = platform.callsFor('setGeoJsonSource');
+      expect(calls, isNotEmpty);
+
+      final geojson = calls.last.positionalArgs[1] as Map<String, dynamic>;
+      expect(geojson['type'], 'FeatureCollection');
+      expect((geojson['features'] as List).length, 1);
+    });
+
+    test('features contain correct id and geometry', () async {
+      platform.reset();
+      await controller.addCircle(
+        const CircleOptions(geometry: LatLng(10, 20)),
+      );
+
+      final calls = platform.callsFor('setGeoJsonSource');
+      final features =
+          (calls.last.positionalArgs[1] as Map)['features'] as List;
+      final feature = features.first as Map<String, dynamic>;
+
+      expect(feature['type'], 'Feature');
+      expect(feature['id'], isNotNull);
+      expect(feature['geometry']['type'], 'Point');
+      // GeoJSON coordinates are [lng, lat]
+      expect(feature['geometry']['coordinates'], [20.0, 10.0]);
+    });
+
+    test('clear produces empty FeatureCollection', () async {
+      await controller.addCircle(
+        const CircleOptions(geometry: LatLng(10, 20)),
+      );
+      platform.reset();
+      await controller.clearCircles();
+
+      final calls = platform.callsFor('setGeoJsonSource');
+      final geojson = calls.last.positionalArgs[1] as Map<String, dynamic>;
+      expect(geojson['features'] as List, isEmpty);
+    });
+  });
+
+  group('Annotation tap callbacks', () {
+    test('onCircleTapped fires when feature tapped', () async {
+      final circle = await controller.addCircle(
+        const CircleOptions(geometry: LatLng(10, 20)),
+      );
+
+      Circle? tappedCircle;
+      controller.onCircleTapped.add((c) => tappedCircle = c);
+
+      platform.onFeatureTappedPlatform.call({
+        'id': circle.id,
+        'layerId': controller.circleManager!.layerIds.first,
+        'point': const Point(100.0, 200.0),
+        'latLng': const LatLng(10, 20),
+      });
+
+      expect(tappedCircle, circle);
+    });
+
+    test('onLineTapped fires when line feature tapped', () async {
+      final line = await controller.addLine(
+        const LineOptions(geometry: [LatLng(0, 0), LatLng(1, 1)]),
+      );
+
+      Line? tappedLine;
+      controller.onLineTapped.add((l) => tappedLine = l);
+
+      platform.onFeatureTappedPlatform.call({
+        'id': line.id,
+        'layerId': controller.lineManager!.layerIds.first,
+        'point': const Point(100.0, 200.0),
+        'latLng': const LatLng(0.5, 0.5),
+      });
+
+      expect(tappedLine, line);
+    });
+
+    test('onFeatureTapped fires for any tapped feature', () async {
+      final circle = await controller.addCircle(
+        const CircleOptions(geometry: LatLng(10, 20)),
+      );
+
+      String? tappedId;
+      controller.onFeatureTapped.add((point, coords, id, layerId, ann) {
+        tappedId = id;
+      });
+
+      platform.onFeatureTappedPlatform.call({
+        'id': circle.id,
+        'layerId': controller.circleManager!.layerIds.first,
+        'point': const Point(100.0, 200.0),
+        'latLng': const LatLng(10, 20),
+      });
+
+      expect(tappedId, circle.id);
+    });
+  });
+}

--- a/maplibre_gl/test/color_tools_test.dart
+++ b/maplibre_gl/test/color_tools_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_gl/maplibre_gl.dart';
+
+void main() {
+  group('MapLibreColorConversion', () {
+    test('red converts to #ff0000', () {
+      expect(const Color(0xFFFF0000).toHexStringRGB(), '#ff0000');
+    });
+
+    test('green converts to #00ff00', () {
+      expect(const Color(0xFF00FF00).toHexStringRGB(), '#00ff00');
+    });
+
+    test('blue converts to #0000ff', () {
+      expect(const Color(0xFF0000FF).toHexStringRGB(), '#0000ff');
+    });
+
+    test('white converts to #ffffff', () {
+      expect(const Color(0xFFFFFFFF).toHexStringRGB(), '#ffffff');
+    });
+
+    test('black converts to #000000', () {
+      expect(const Color(0xFF000000).toHexStringRGB(), '#000000');
+    });
+
+    test('alpha channel is ignored', () {
+      // Same RGB but different alpha
+      expect(const Color(0x80FF0000).toHexStringRGB(), '#ff0000');
+      expect(const Color(0x00FF0000).toHexStringRGB(), '#ff0000');
+    });
+
+    test('single-digit hex values are zero-padded', () {
+      expect(const Color(0xFF010203).toHexStringRGB(), '#010203');
+    });
+  });
+}

--- a/maplibre_gl/test/controller_test.dart
+++ b/maplibre_gl/test/controller_test.dart
@@ -41,7 +41,10 @@ void main() {
       );
 
       final calls = platform.callsFor('animateCamera');
-      expect(calls.first.namedArgs['duration'], const Duration(milliseconds: 500));
+      expect(
+        calls.first.namedArgs['duration'],
+        const Duration(milliseconds: 500),
+      );
     });
 
     test('moveCamera delegates to platform', () async {
@@ -115,8 +118,7 @@ void main() {
       expect(calls.first.positionalArgs.first, 'src-1');
     });
 
-    test('setGeoJsonFeature delegates to setFeatureForGeoJsonSource',
-        () async {
+    test('setGeoJsonFeature delegates to setFeatureForGeoJsonSource', () async {
       final feature = <String, dynamic>{
         'type': 'Feature',
         'id': 'f1',
@@ -233,8 +235,7 @@ void main() {
 
   group('Map queries delegation', () {
     test('toScreenLocation delegates to platform', () async {
-      final result =
-          await controller.toScreenLocation(const LatLng(10, 20));
+      final result = await controller.toScreenLocation(const LatLng(10, 20));
 
       expect(result, const Point(0, 0));
     });
@@ -290,8 +291,9 @@ void main() {
 
     test('camera idle sets isCameraMoving to false', () {
       platform.onCameraMoveStartedPlatform.call(null);
-      platform.onCameraIdlePlatform
-          .call(const CameraPosition(target: LatLng(5, 5)));
+      platform.onCameraIdlePlatform.call(
+        const CameraPosition(target: LatLng(5, 5)),
+      );
 
       expect(controller.isCameraMoving, isFalse);
     });
@@ -302,8 +304,7 @@ void main() {
 
       expect(controller.cameraPosition, newPos);
     });
-
-});
+  });
 
   group('Callback wiring', () {
     test('onMapClick fires from platform event', () {
@@ -369,8 +370,9 @@ void main() {
         },
       );
 
-      platform.onCameraTrackingChangedPlatform
-          .call(MyLocationTrackingMode.tracking);
+      platform.onCameraTrackingChangedPlatform.call(
+        MyLocationTrackingMode.tracking,
+      );
 
       expect(receivedMode, MyLocationTrackingMode.tracking);
 

--- a/maplibre_gl/test/controller_test.dart
+++ b/maplibre_gl/test/controller_test.dart
@@ -1,0 +1,392 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_gl/maplibre_gl.dart';
+
+import 'helpers/fake_platform.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FakeMapLibrePlatform platform;
+  late MapLibreMapController controller;
+
+  setUp(() {
+    platform = FakeMapLibrePlatform();
+    controller = MapLibreMapController(
+      maplibrePlatform: platform,
+      initialCameraPosition: const CameraPosition(target: LatLng(0, 0)),
+      annotationOrder: AnnotationType.values,
+      annotationConsumeTapEvents: AnnotationType.values,
+    );
+    platform.reset();
+  });
+
+  group('Camera delegation', () {
+    test('animateCamera delegates to platform', () async {
+      final update = CameraUpdate.newLatLng(const LatLng(10, 20));
+      await controller.animateCamera(update);
+
+      final calls = platform.callsFor('animateCamera');
+      expect(calls.length, 1);
+      expect(calls.first.positionalArgs.first, update);
+      expect(calls.first.namedArgs['duration'], isNull);
+    });
+
+    test('animateCamera with duration', () async {
+      final update = CameraUpdate.zoomIn();
+      await controller.animateCamera(
+        update,
+        duration: const Duration(milliseconds: 500),
+      );
+
+      final calls = platform.callsFor('animateCamera');
+      expect(calls.first.namedArgs['duration'], const Duration(milliseconds: 500));
+    });
+
+    test('moveCamera delegates to platform', () async {
+      final update = CameraUpdate.newLatLng(const LatLng(10, 20));
+      await controller.moveCamera(update);
+
+      final calls = platform.callsFor('moveCamera');
+      expect(calls.length, 1);
+      expect(calls.first.positionalArgs.first, update);
+    });
+
+    test('easeCamera delegates to platform', () async {
+      final update = CameraUpdate.zoomTo(12);
+      await controller.easeCamera(
+        update,
+        duration: const Duration(seconds: 1),
+      );
+
+      final calls = platform.callsFor('easeCamera');
+      expect(calls.length, 1);
+      expect(calls.first.positionalArgs.first, update);
+      expect(calls.first.namedArgs['duration'], const Duration(seconds: 1));
+    });
+
+    test('queryCameraPosition delegates to platform', () async {
+      final result = await controller.queryCameraPosition();
+
+      expect(platform.wasCalled('queryCameraPosition'), isTrue);
+      expect(result, isNotNull);
+      expect(result!.target, const LatLng(0, 0));
+    });
+  });
+
+  group('Source management delegation', () {
+    test('addGeoJsonSource delegates to platform', () async {
+      final geojson = buildFeatureCollection([]);
+      await controller.addGeoJsonSource('src-1', geojson, promoteId: 'id');
+
+      final calls = platform.callsFor('addGeoJsonSource');
+      expect(calls.length, 1);
+      expect(calls.first.positionalArgs[0], 'src-1');
+      expect(calls.first.positionalArgs[1], geojson);
+      expect(calls.first.namedArgs['promoteId'], 'id');
+    });
+
+    test('setGeoJsonSource delegates to platform', () async {
+      final geojson = buildFeatureCollection([]);
+      await controller.setGeoJsonSource('src-1', geojson);
+
+      final calls = platform.callsFor('setGeoJsonSource');
+      expect(calls.length, 1);
+      expect(calls.first.positionalArgs[0], 'src-1');
+    });
+
+    test('addSource delegates to platform', () async {
+      const props = VectorSourceProperties(
+        url: 'https://example.com/tiles.json',
+      );
+      await controller.addSource('vec-1', props);
+
+      final calls = platform.callsFor('addSource');
+      expect(calls.length, 1);
+      expect(calls.first.positionalArgs[0], 'vec-1');
+    });
+
+    test('removeSource delegates to platform', () async {
+      await controller.removeSource('src-1');
+
+      final calls = platform.callsFor('removeSource');
+      expect(calls.length, 1);
+      expect(calls.first.positionalArgs.first, 'src-1');
+    });
+
+    test('setGeoJsonFeature delegates to setFeatureForGeoJsonSource',
+        () async {
+      final feature = <String, dynamic>{
+        'type': 'Feature',
+        'id': 'f1',
+        'properties': <String, dynamic>{},
+      };
+      await controller.setGeoJsonFeature('src-1', feature);
+
+      final calls = platform.callsFor('setFeatureForGeoJsonSource');
+      expect(calls.length, 1);
+      expect(calls.first.positionalArgs[0], 'src-1');
+      expect(calls.first.positionalArgs[1], feature);
+    });
+  });
+
+  group('Layer management delegation', () {
+    test('addCircleLayer delegates to platform', () async {
+      await controller.addCircleLayer(
+        'src-1',
+        'layer-1',
+        const CircleLayerProperties(circleColor: '#ff0000'),
+      );
+
+      final calls = platform.callsFor('addCircleLayer');
+      expect(calls.length, 1);
+      expect(calls.first.positionalArgs[0], 'src-1');
+      expect(calls.first.positionalArgs[1], 'layer-1');
+    });
+
+    test('addLineLayer delegates to platform', () async {
+      await controller.addLineLayer(
+        'src-1',
+        'layer-1',
+        const LineLayerProperties(lineColor: '#00ff00'),
+      );
+
+      final calls = platform.callsFor('addLineLayer');
+      expect(calls.length, 1);
+      expect(calls.first.positionalArgs[0], 'src-1');
+      expect(calls.first.positionalArgs[1], 'layer-1');
+    });
+
+    test('addFillLayer delegates to platform', () async {
+      await controller.addFillLayer(
+        'src-1',
+        'layer-1',
+        const FillLayerProperties(fillColor: '#0000ff'),
+      );
+
+      final calls = platform.callsFor('addFillLayer');
+      expect(calls.length, 1);
+      expect(calls.first.positionalArgs[0], 'src-1');
+      expect(calls.first.positionalArgs[1], 'layer-1');
+    });
+
+    test('addSymbolLayer delegates to platform', () async {
+      await controller.addSymbolLayer(
+        'src-1',
+        'layer-1',
+        const SymbolLayerProperties(iconImage: 'marker'),
+      );
+
+      final calls = platform.callsFor('addSymbolLayer');
+      expect(calls.length, 1);
+      expect(calls.first.positionalArgs[0], 'src-1');
+      expect(calls.first.positionalArgs[1], 'layer-1');
+    });
+
+    test('addLayer dispatches to correct typed method', () async {
+      await controller.addLayer(
+        'src-1',
+        'layer-1',
+        const FillLayerProperties(fillColor: '#0000ff'),
+      );
+
+      expect(platform.wasCalled('addFillLayer'), isTrue);
+    });
+
+    test('addLayer with CircleLayerProperties', () async {
+      await controller.addLayer(
+        'src-1',
+        'layer-1',
+        const CircleLayerProperties(circleColor: '#ff0000'),
+      );
+
+      expect(platform.wasCalled('addCircleLayer'), isTrue);
+    });
+
+    test('removeLayer delegates to platform', () async {
+      await controller.removeLayer('layer-1');
+
+      final calls = platform.callsFor('removeLayer');
+      expect(calls.length, 1);
+      expect(calls.first.positionalArgs.first, 'layer-1');
+    });
+
+    test('setLayerVisibility delegates to platform', () async {
+      await controller.setLayerVisibility('layer-1', false);
+
+      final calls = platform.callsFor('setLayerVisibility');
+      expect(calls.length, 1);
+      expect(calls.first.positionalArgs[0], 'layer-1');
+      expect(calls.first.positionalArgs[1], false);
+    });
+
+    test('addImageLayer delegates to addLayer on platform', () async {
+      await controller.addImageLayer('img-layer', 'img-source');
+
+      final calls = platform.callsFor('addLayer');
+      expect(calls.length, 1);
+      expect(calls.first.positionalArgs[0], 'img-layer');
+      expect(calls.first.positionalArgs[1], 'img-source');
+    });
+  });
+
+  group('Map queries delegation', () {
+    test('toScreenLocation delegates to platform', () async {
+      final result =
+          await controller.toScreenLocation(const LatLng(10, 20));
+
+      expect(result, const Point(0, 0));
+    });
+
+    test('toLatLng delegates to platform', () async {
+      final result = await controller.toLatLng(const Point(100, 200));
+
+      expect(result, const LatLng(0, 0));
+    });
+
+    test('getVisibleRegion delegates to platform', () async {
+      final bounds = await controller.getVisibleRegion();
+
+      expect(bounds.southwest, const LatLng(-1, -1));
+      expect(bounds.northeast, const LatLng(1, 1));
+    });
+
+    test('requestMyLocationLatLng delegates to platform', () async {
+      final loc = await controller.requestMyLocationLatLng();
+
+      expect(loc, const LatLng(0, 0));
+    });
+  });
+
+  group('Style delegation', () {
+    test('setStyle delegates to platform', () async {
+      await controller.setStyle('mapbox://styles/test');
+
+      final calls = platform.callsFor('setStyle');
+      expect(calls.length, 1);
+      expect(calls.first.positionalArgs.first, 'mapbox://styles/test');
+    });
+  });
+
+  group('Camera state tracking', () {
+    test('initial cameraPosition matches constructor', () {
+      expect(controller.cameraPosition, isNotNull);
+      expect(
+        controller.cameraPosition!.target,
+        const LatLng(0, 0),
+      );
+    });
+
+    test('isCameraMoving is initially false', () {
+      expect(controller.isCameraMoving, isFalse);
+    });
+
+    test('camera move started sets isCameraMoving to true', () {
+      platform.onCameraMoveStartedPlatform.call(null);
+
+      expect(controller.isCameraMoving, isTrue);
+    });
+
+    test('camera idle sets isCameraMoving to false', () {
+      platform.onCameraMoveStartedPlatform.call(null);
+      platform.onCameraIdlePlatform
+          .call(const CameraPosition(target: LatLng(5, 5)));
+
+      expect(controller.isCameraMoving, isFalse);
+    });
+
+    test('camera move updates cameraPosition', () {
+      const newPos = CameraPosition(target: LatLng(10, 20), zoom: 12);
+      platform.onCameraMovePlatform.call(newPos);
+
+      expect(controller.cameraPosition, newPos);
+    });
+
+});
+
+  group('Callback wiring', () {
+    test('onMapClick fires from platform event', () {
+      Point<double>? clickPoint;
+      LatLng? clickLatLng;
+
+      final clickController = MapLibreMapController(
+        maplibrePlatform: platform,
+        initialCameraPosition: const CameraPosition(target: LatLng(0, 0)),
+        annotationOrder: AnnotationType.values,
+        annotationConsumeTapEvents: AnnotationType.values,
+        onMapClick: (point, latLng) {
+          clickPoint = point;
+          clickLatLng = latLng;
+        },
+      );
+
+      platform.onMapClickPlatform.call({
+        'point': const Point<double>(100, 200),
+        'latLng': const LatLng(10, 20),
+      });
+
+      expect(clickPoint, const Point<double>(100, 200));
+      expect(clickLatLng, const LatLng(10, 20));
+
+      // Avoid leak
+      clickController.dispose();
+    });
+
+    test('onMapLongClick fires from platform event', () {
+      LatLng? longClickLatLng;
+
+      final longClickController = MapLibreMapController(
+        maplibrePlatform: platform,
+        initialCameraPosition: const CameraPosition(target: LatLng(0, 0)),
+        annotationOrder: AnnotationType.values,
+        annotationConsumeTapEvents: AnnotationType.values,
+        onMapLongClick: (point, latLng) {
+          longClickLatLng = latLng;
+        },
+      );
+
+      platform.onMapLongClickPlatform.call({
+        'point': const Point<double>(100, 200),
+        'latLng': const LatLng(30, 40),
+      });
+
+      expect(longClickLatLng, const LatLng(30, 40));
+
+      longClickController.dispose();
+    });
+
+    test('onCameraTrackingChanged fires from platform event', () {
+      MyLocationTrackingMode? receivedMode;
+
+      final trackingController = MapLibreMapController(
+        maplibrePlatform: platform,
+        initialCameraPosition: const CameraPosition(target: LatLng(0, 0)),
+        annotationOrder: AnnotationType.values,
+        annotationConsumeTapEvents: AnnotationType.values,
+        onCameraTrackingChanged: (mode) {
+          receivedMode = mode;
+        },
+      );
+
+      platform.onCameraTrackingChangedPlatform
+          .call(MyLocationTrackingMode.tracking);
+
+      expect(receivedMode, MyLocationTrackingMode.tracking);
+
+      trackingController.dispose();
+    });
+  });
+
+  group('Dispose', () {
+    test('isDisposed is initially false', () {
+      expect(controller.isDisposed, isFalse);
+    });
+
+    test('isDisposed is true after dispose', () {
+      controller.dispose();
+
+      expect(controller.isDisposed, isTrue);
+    });
+  });
+}

--- a/maplibre_gl/test/helpers/fake_platform.dart
+++ b/maplibre_gl/test/helpers/fake_platform.dart
@@ -1,0 +1,465 @@
+import 'dart:math';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/widgets.dart';
+import 'package:maplibre_gl_platform_interface/maplibre_gl_platform_interface.dart';
+
+/// A call record for verifying interactions with [FakeMapLibrePlatform].
+class PlatformCall {
+  final String method;
+  final List<dynamic> positionalArgs;
+  final Map<String, dynamic> namedArgs;
+
+  PlatformCall(this.method, [this.positionalArgs = const [], this.namedArgs = const {}]);
+
+  @override
+  String toString() => 'PlatformCall($method, $positionalArgs, $namedArgs)';
+}
+
+/// Fake implementation of [MapLibrePlatform] that records all method calls.
+class FakeMapLibrePlatform extends MapLibrePlatform {
+  final calls = <PlatformCall>[];
+
+  /// Clears recorded calls.
+  void reset() => calls.clear();
+
+  /// Returns all calls with the given method name.
+  List<PlatformCall> callsFor(String method) =>
+      calls.where((c) => c.method == method).toList();
+
+  /// Whether a method was called at least once.
+  bool wasCalled(String method) => calls.any((c) => c.method == method);
+
+  @override
+  Future<void> initPlatform(int id) async {
+    calls.add(PlatformCall('initPlatform', [id]));
+  }
+
+  @override
+  Widget buildView(
+    Map<String, dynamic> creationParams,
+    OnPlatformViewCreatedCallback onPlatformViewCreated,
+    Set<Factory<OneSequenceGestureRecognizer>>? gestureRecognizers,
+  ) {
+    calls.add(PlatformCall('buildView'));
+    return const SizedBox.shrink();
+  }
+
+  @override
+  Future<CameraPosition?> updateMapOptions(
+    Map<String, dynamic> optionsUpdate,
+  ) async {
+    calls.add(PlatformCall('updateMapOptions', [optionsUpdate]));
+    return const CameraPosition(target: LatLng(0, 0));
+  }
+
+  @override
+  Future<bool?> animateCamera(CameraUpdate cameraUpdate,
+      {Duration? duration}) async {
+    calls.add(PlatformCall('animateCamera', [cameraUpdate], {'duration': duration}));
+    return true;
+  }
+
+  @override
+  Future<bool?> moveCamera(CameraUpdate cameraUpdate) async {
+    calls.add(PlatformCall('moveCamera', [cameraUpdate]));
+    return true;
+  }
+
+  @override
+  Future<void> updateMyLocationTrackingMode(
+    MyLocationTrackingMode myLocationTrackingMode,
+  ) async {
+    calls.add(PlatformCall('updateMyLocationTrackingMode', [myLocationTrackingMode]));
+  }
+
+  @override
+  Future<void> matchMapLanguageWithDeviceDefault() async {
+    calls.add(PlatformCall('matchMapLanguageWithDeviceDefault'));
+  }
+
+  @override
+  void resizeWebMap() {}
+
+  @override
+  void forceResizeWebMap() {}
+
+  @override
+  Future<void> updateContentInsets(EdgeInsets insets, bool animated) async {}
+
+  @override
+  Future<void> setMapLanguage(String language) async {}
+
+  @override
+  Future<void> setTelemetryEnabled(bool enabled) async {}
+
+  @override
+  Future<bool> getTelemetryEnabled() async => false;
+
+  @override
+  Future<void> setMaximumFps(int fps) async {}
+
+  @override
+  Future<void> forceOnlineMode() async {}
+
+  @override
+  Future<bool> easeCamera(CameraUpdate cameraUpdate,
+      {Duration? duration}) async {
+    calls.add(PlatformCall('easeCamera', [cameraUpdate], {'duration': duration}));
+    return true;
+  }
+
+  @override
+  Future<CameraPosition?> queryCameraPosition() async {
+    calls.add(PlatformCall('queryCameraPosition'));
+    return const CameraPosition(target: LatLng(0, 0));
+  }
+
+  @override
+  Future<bool> editGeoJsonSource(String id, String data) async => true;
+
+  @override
+  Future<bool> editGeoJsonUrl(String id, String url) async => true;
+
+  @override
+  Future<bool> setLayerFilter(String layerId, String filter) async => true;
+
+  @override
+  Future<String?> getStyle() async => null;
+
+  @override
+  Future<void> setCustomHeaders(
+    Map<String, String> headers,
+    List<String> filter,
+  ) async {}
+
+  @override
+  Future<Map<String, String>> getCustomHeaders() async => {};
+
+  @override
+  Future<List> queryRenderedFeatures(
+    Point<double> point,
+    List<String> layerIds,
+    List<Object>? filter,
+  ) async =>
+      [];
+
+  @override
+  Future<List> queryRenderedFeaturesInRect(
+    Rect rect,
+    List<String> layerIds,
+    String? filter,
+  ) async =>
+      [];
+
+  @override
+  Future<List> querySourceFeatures(
+    String sourceId,
+    String? sourceLayerId,
+    List<Object>? filter,
+  ) async =>
+      [];
+
+  @override
+  Future invalidateAmbientCache() async {}
+
+  @override
+  Future clearAmbientCache() async {}
+
+  @override
+  Future<LatLng?> requestMyLocationLatLng() async => const LatLng(0, 0);
+
+  @override
+  Future<LatLngBounds> getVisibleRegion() async => LatLngBounds(
+        southwest: const LatLng(-1, -1),
+        northeast: const LatLng(1, 1),
+      );
+
+  @override
+  Future<void> addImage(String name, Uint8List bytes,
+      [bool sdf = false]) async {}
+
+  @override
+  Future<void> addImageSource(
+    String imageSourceId,
+    Uint8List bytes,
+    LatLngQuad coordinates,
+  ) async {}
+
+  @override
+  Future<void> updateImageSource(
+    String imageSourceId,
+    Uint8List? bytes,
+    LatLngQuad? coordinates,
+  ) async {}
+
+  @override
+  Future<void> addLayer(
+    String imageLayerId,
+    String imageSourceId,
+    double? minzoom,
+    double? maxzoom,
+  ) async {
+    calls.add(PlatformCall('addLayer', [imageLayerId, imageSourceId, minzoom, maxzoom]));
+  }
+
+  @override
+  Future<void> addLayerBelow(
+    String imageLayerId,
+    String imageSourceId,
+    String belowLayerId,
+    double? minzoom,
+    double? maxzoom,
+  ) async {
+    calls.add(PlatformCall('addLayerBelow', [imageLayerId, imageSourceId, belowLayerId]));
+  }
+
+  @override
+  Future<void> removeLayer(String layerId) async {
+    calls.add(PlatformCall('removeLayer', [layerId]));
+  }
+
+  @override
+  Future<List> getLayerIds() async => [];
+
+  @override
+  Future<List> getSourceIds() async => [];
+
+  @override
+  Future<void> setFilter(String layerId, dynamic filter) async {}
+
+  @override
+  Future<dynamic> getFilter(String layerId) async => null;
+
+  @override
+  Future<Point> toScreenLocation(LatLng latLng) async => const Point(0, 0);
+
+  @override
+  Future<List<Point>> toScreenLocationBatch(Iterable<LatLng> latLngs) async =>
+      [];
+
+  @override
+  Future<LatLng> toLatLng(Point screenLocation) async => const LatLng(0, 0);
+
+  @override
+  Future<double> getMetersPerPixelAtLatitude(double latitude) async => 1.0;
+
+  @override
+  Future<void> addGeoJsonSource(
+    String sourceId,
+    Map<String, dynamic> geojson, {
+    String? promoteId,
+  }) async {
+    calls.add(PlatformCall(
+      'addGeoJsonSource',
+      [sourceId, geojson],
+      {'promoteId': promoteId},
+    ));
+  }
+
+  @override
+  Future<void> setGeoJsonSource(
+    String sourceId,
+    Map<String, dynamic> geojson,
+  ) async {
+    calls.add(PlatformCall('setGeoJsonSource', [sourceId, geojson]));
+  }
+
+  @override
+  Future<void> setCameraBounds({
+    required double west,
+    required double north,
+    required double south,
+    required double east,
+    required int padding,
+  }) async {}
+
+  @override
+  Future<void> setFeatureForGeoJsonSource(
+    String sourceId,
+    Map<String, dynamic> geojsonFeature,
+  ) async {
+    calls.add(PlatformCall('setFeatureForGeoJsonSource', [sourceId, geojsonFeature]));
+  }
+
+  @override
+  Future<void> setFeatureState(
+    String sourceId,
+    String featureId,
+    Map<String, dynamic> state, {
+    String? sourceLayer,
+  }) async {}
+
+  @override
+  Future<void> removeFeatureState(
+    String sourceId, {
+    String? featureId,
+    String? stateKey,
+    String? sourceLayer,
+  }) async {}
+
+  @override
+  Future<Map<String, dynamic>?> getFeatureState(
+    String sourceId,
+    String featureId, {
+    String? sourceLayer,
+  }) async =>
+      null;
+
+  @override
+  Future<void> removeSource(String sourceId) async {
+    calls.add(PlatformCall('removeSource', [sourceId]));
+  }
+
+  @override
+  Future<void> addSymbolLayer(
+    String sourceId,
+    String layerId,
+    Map<String, dynamic> properties, {
+    String? belowLayerId,
+    String? sourceLayer,
+    double? minzoom,
+    double? maxzoom,
+    dynamic filter,
+    required bool enableInteraction,
+  }) async {
+    calls.add(PlatformCall('addSymbolLayer', [sourceId, layerId, properties]));
+  }
+
+  @override
+  Future<void> addLineLayer(
+    String sourceId,
+    String layerId,
+    Map<String, dynamic> properties, {
+    String? belowLayerId,
+    String? sourceLayer,
+    double? minzoom,
+    double? maxzoom,
+    dynamic filter,
+    required bool enableInteraction,
+  }) async {
+    calls.add(PlatformCall('addLineLayer', [sourceId, layerId, properties]));
+  }
+
+  @override
+  Future<void> setLayerProperties(
+    String layerId,
+    Map<String, dynamic> properties,
+  ) async {
+    calls.add(PlatformCall('setLayerProperties', [layerId, properties]));
+  }
+
+  @override
+  Future<void> addCircleLayer(
+    String sourceId,
+    String layerId,
+    Map<String, dynamic> properties, {
+    String? belowLayerId,
+    String? sourceLayer,
+    double? minzoom,
+    double? maxzoom,
+    dynamic filter,
+    required bool enableInteraction,
+  }) async {
+    calls.add(PlatformCall('addCircleLayer', [sourceId, layerId, properties]));
+  }
+
+  @override
+  Future<void> addFillLayer(
+    String sourceId,
+    String layerId,
+    Map<String, dynamic> properties, {
+    String? belowLayerId,
+    String? sourceLayer,
+    double? minzoom,
+    double? maxzoom,
+    dynamic filter,
+    required bool enableInteraction,
+  }) async {
+    calls.add(PlatformCall('addFillLayer', [sourceId, layerId, properties]));
+  }
+
+  @override
+  Future<void> addFillExtrusionLayer(
+    String sourceId,
+    String layerId,
+    Map<String, dynamic> properties, {
+    String? belowLayerId,
+    String? sourceLayer,
+    double? minzoom,
+    double? maxzoom,
+    dynamic filter,
+    required bool enableInteraction,
+  }) async {
+    calls.add(PlatformCall('addFillExtrusionLayer', [sourceId, layerId, properties]));
+  }
+
+  @override
+  Future<void> addRasterLayer(
+    String sourceId,
+    String layerId,
+    Map<String, dynamic> properties, {
+    String? belowLayerId,
+    String? sourceLayer,
+    double? minzoom,
+    double? maxzoom,
+  }) async {
+    calls.add(PlatformCall('addRasterLayer', [sourceId, layerId, properties]));
+  }
+
+  @override
+  Future<void> addHillshadeLayer(
+    String sourceId,
+    String layerId,
+    Map<String, dynamic> properties, {
+    String? belowLayerId,
+    String? sourceLayer,
+    double? minzoom,
+    double? maxzoom,
+  }) async {
+    calls.add(PlatformCall('addHillshadeLayer', [sourceId, layerId, properties]));
+  }
+
+  @override
+  Future<void> addHeatmapLayer(
+    String sourceId,
+    String layerId,
+    Map<String, dynamic> properties, {
+    String? belowLayerId,
+    String? sourceLayer,
+    double? minzoom,
+    double? maxzoom,
+  }) async {
+    calls.add(PlatformCall('addHeatmapLayer', [sourceId, layerId, properties]));
+  }
+
+  @override
+  Future<void> addSource(String sourceId, SourceProperties properties) async {
+    calls.add(PlatformCall('addSource', [sourceId, properties]));
+  }
+
+  @override
+  Future<void> setLayerVisibility(String layerId, bool visible) async {
+    calls.add(PlatformCall('setLayerVisibility', [layerId, visible]));
+  }
+
+  @override
+  Future<bool?> getLayerVisibility(String layerId) async => true;
+
+  @override
+  Future<Size> setWebMapToCustomSize(Size size) async => size;
+
+  @override
+  Future<void> waitUntilMapIsIdleAfterMovement() async {}
+
+  @override
+  Future<void> waitUntilMapTilesAreLoaded() async {}
+
+  @override
+  Future<String> takeWebSnapshot() async => '';
+
+  @override
+  Future<void> setStyle(String styleString) async {
+    calls.add(PlatformCall('setStyle', [styleString]));
+  }
+}

--- a/maplibre_gl/test/helpers/fake_platform.dart
+++ b/maplibre_gl/test/helpers/fake_platform.dart
@@ -10,7 +10,11 @@ class PlatformCall {
   final List<dynamic> positionalArgs;
   final Map<String, dynamic> namedArgs;
 
-  PlatformCall(this.method, [this.positionalArgs = const [], this.namedArgs = const {}]);
+  PlatformCall(
+    this.method, [
+    this.positionalArgs = const [],
+    this.namedArgs = const {},
+  ]);
 
   @override
   String toString() => 'PlatformCall($method, $positionalArgs, $namedArgs)';
@@ -54,9 +58,13 @@ class FakeMapLibrePlatform extends MapLibrePlatform {
   }
 
   @override
-  Future<bool?> animateCamera(CameraUpdate cameraUpdate,
-      {Duration? duration}) async {
-    calls.add(PlatformCall('animateCamera', [cameraUpdate], {'duration': duration}));
+  Future<bool?> animateCamera(
+    CameraUpdate cameraUpdate, {
+    Duration? duration,
+  }) async {
+    calls.add(
+      PlatformCall('animateCamera', [cameraUpdate], {'duration': duration}),
+    );
     return true;
   }
 
@@ -70,7 +78,9 @@ class FakeMapLibrePlatform extends MapLibrePlatform {
   Future<void> updateMyLocationTrackingMode(
     MyLocationTrackingMode myLocationTrackingMode,
   ) async {
-    calls.add(PlatformCall('updateMyLocationTrackingMode', [myLocationTrackingMode]));
+    calls.add(
+      PlatformCall('updateMyLocationTrackingMode', [myLocationTrackingMode]),
+    );
   }
 
   @override
@@ -103,9 +113,13 @@ class FakeMapLibrePlatform extends MapLibrePlatform {
   Future<void> forceOnlineMode() async {}
 
   @override
-  Future<bool> easeCamera(CameraUpdate cameraUpdate,
-      {Duration? duration}) async {
-    calls.add(PlatformCall('easeCamera', [cameraUpdate], {'duration': duration}));
+  Future<bool> easeCamera(
+    CameraUpdate cameraUpdate, {
+    Duration? duration,
+  }) async {
+    calls.add(
+      PlatformCall('easeCamera', [cameraUpdate], {'duration': duration}),
+    );
     return true;
   }
 
@@ -141,24 +155,21 @@ class FakeMapLibrePlatform extends MapLibrePlatform {
     Point<double> point,
     List<String> layerIds,
     List<Object>? filter,
-  ) async =>
-      [];
+  ) async => [];
 
   @override
   Future<List> queryRenderedFeaturesInRect(
     Rect rect,
     List<String> layerIds,
     String? filter,
-  ) async =>
-      [];
+  ) async => [];
 
   @override
   Future<List> querySourceFeatures(
     String sourceId,
     String? sourceLayerId,
     List<Object>? filter,
-  ) async =>
-      [];
+  ) async => [];
 
   @override
   Future invalidateAmbientCache() async {}
@@ -171,13 +182,16 @@ class FakeMapLibrePlatform extends MapLibrePlatform {
 
   @override
   Future<LatLngBounds> getVisibleRegion() async => LatLngBounds(
-        southwest: const LatLng(-1, -1),
-        northeast: const LatLng(1, 1),
-      );
+    southwest: const LatLng(-1, -1),
+    northeast: const LatLng(1, 1),
+  );
 
   @override
-  Future<void> addImage(String name, Uint8List bytes,
-      [bool sdf = false]) async {}
+  Future<void> addImage(
+    String name,
+    Uint8List bytes, [
+    bool sdf = false,
+  ]) async {}
 
   @override
   Future<void> addImageSource(
@@ -200,7 +214,9 @@ class FakeMapLibrePlatform extends MapLibrePlatform {
     double? minzoom,
     double? maxzoom,
   ) async {
-    calls.add(PlatformCall('addLayer', [imageLayerId, imageSourceId, minzoom, maxzoom]));
+    calls.add(
+      PlatformCall('addLayer', [imageLayerId, imageSourceId, minzoom, maxzoom]),
+    );
   }
 
   @override
@@ -211,7 +227,13 @@ class FakeMapLibrePlatform extends MapLibrePlatform {
     double? minzoom,
     double? maxzoom,
   ) async {
-    calls.add(PlatformCall('addLayerBelow', [imageLayerId, imageSourceId, belowLayerId]));
+    calls.add(
+      PlatformCall('addLayerBelow', [
+        imageLayerId,
+        imageSourceId,
+        belowLayerId,
+      ]),
+    );
   }
 
   @override
@@ -250,11 +272,13 @@ class FakeMapLibrePlatform extends MapLibrePlatform {
     Map<String, dynamic> geojson, {
     String? promoteId,
   }) async {
-    calls.add(PlatformCall(
-      'addGeoJsonSource',
-      [sourceId, geojson],
-      {'promoteId': promoteId},
-    ));
+    calls.add(
+      PlatformCall(
+        'addGeoJsonSource',
+        [sourceId, geojson],
+        {'promoteId': promoteId},
+      ),
+    );
   }
 
   @override
@@ -279,7 +303,9 @@ class FakeMapLibrePlatform extends MapLibrePlatform {
     String sourceId,
     Map<String, dynamic> geojsonFeature,
   ) async {
-    calls.add(PlatformCall('setFeatureForGeoJsonSource', [sourceId, geojsonFeature]));
+    calls.add(
+      PlatformCall('setFeatureForGeoJsonSource', [sourceId, geojsonFeature]),
+    );
   }
 
   @override
@@ -303,8 +329,7 @@ class FakeMapLibrePlatform extends MapLibrePlatform {
     String sourceId,
     String featureId, {
     String? sourceLayer,
-  }) async =>
-      null;
+  }) async => null;
 
   @override
   Future<void> removeSource(String sourceId) async {
@@ -391,7 +416,9 @@ class FakeMapLibrePlatform extends MapLibrePlatform {
     dynamic filter,
     required bool enableInteraction,
   }) async {
-    calls.add(PlatformCall('addFillExtrusionLayer', [sourceId, layerId, properties]));
+    calls.add(
+      PlatformCall('addFillExtrusionLayer', [sourceId, layerId, properties]),
+    );
   }
 
   @override
@@ -417,7 +444,9 @@ class FakeMapLibrePlatform extends MapLibrePlatform {
     double? minzoom,
     double? maxzoom,
   }) async {
-    calls.add(PlatformCall('addHillshadeLayer', [sourceId, layerId, properties]));
+    calls.add(
+      PlatformCall('addHillshadeLayer', [sourceId, layerId, properties]),
+    );
   }
 
   @override

--- a/maplibre_gl/test/layer_properties_test.dart
+++ b/maplibre_gl/test/layer_properties_test.dart
@@ -147,8 +147,7 @@ void main() {
         fillExtrusionHeight: 100,
         fillExtrusionOpacity: 0.9,
       );
-      final restored =
-          FillExtrusionLayerProperties.fromJson(original.toJson());
+      final restored = FillExtrusionLayerProperties.fromJson(original.toJson());
       expect(restored.fillExtrusionColor, '#333333');
       expect(restored.fillExtrusionHeight, 100);
       expect(restored.fillExtrusionOpacity, 0.9);

--- a/maplibre_gl/test/layer_properties_test.dart
+++ b/maplibre_gl/test/layer_properties_test.dart
@@ -1,0 +1,242 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_gl/maplibre_gl.dart';
+
+void main() {
+  group('CircleLayerProperties', () {
+    test('toJson with skipNulls omits null fields', () {
+      const props = CircleLayerProperties(circleRadius: 10);
+      final json = props.toJson();
+      expect(json['circle-radius'], 10);
+      expect(json.containsKey('circle-color'), isFalse);
+    });
+
+    test('toJson without skipNulls includes null fields', () {
+      const props = CircleLayerProperties(circleRadius: 10);
+      final json = props.toJson(skipNulls: false);
+      expect(json['circle-radius'], 10);
+      expect(json.containsKey('circle-color'), isTrue);
+      expect(json['circle-color'], isNull);
+    });
+
+    test('uses hyphenated key names', () {
+      const props = CircleLayerProperties(
+        circleStrokeWidth: 2,
+        circleStrokeColor: '#FF0000',
+      );
+      final json = props.toJson();
+      expect(json.containsKey('circle-stroke-width'), isTrue);
+      expect(json.containsKey('circle-stroke-color'), isTrue);
+    });
+
+    test('fromJson roundtrip', () {
+      const original = CircleLayerProperties(
+        circleRadius: 10,
+        circleColor: '#FF0000',
+        circleOpacity: 0.8,
+        visibility: 'visible',
+      );
+      final restored = CircleLayerProperties.fromJson(original.toJson());
+      expect(restored.circleRadius, 10);
+      expect(restored.circleColor, '#FF0000');
+      expect(restored.circleOpacity, 0.8);
+      expect(restored.visibility, 'visible');
+    });
+  });
+
+  group('LineLayerProperties', () {
+    test('toJson with skipNulls', () {
+      const props = LineLayerProperties(
+        lineColor: '#0000FF',
+        lineWidth: 3,
+      );
+      final json = props.toJson();
+      expect(json['line-color'], '#0000FF');
+      expect(json['line-width'], 3);
+      expect(json.containsKey('line-opacity'), isFalse);
+    });
+
+    test('toJson without skipNulls', () {
+      const props = LineLayerProperties(lineColor: '#0000FF');
+      final json = props.toJson(skipNulls: false);
+      expect(json.containsKey('line-opacity'), isTrue);
+    });
+
+    test('fromJson roundtrip', () {
+      const original = LineLayerProperties(
+        lineColor: '#0000FF',
+        lineWidth: 3,
+        lineDasharray: [2, 4],
+      );
+      final restored = LineLayerProperties.fromJson(original.toJson());
+      expect(restored.lineColor, '#0000FF');
+      expect(restored.lineWidth, 3);
+      expect(restored.lineDasharray, [2, 4]);
+    });
+  });
+
+  group('FillLayerProperties', () {
+    test('toJson with skipNulls', () {
+      const props = FillLayerProperties(
+        fillColor: '#00FF00',
+        fillOpacity: 0.5,
+      );
+      final json = props.toJson();
+      expect(json['fill-color'], '#00FF00');
+      expect(json['fill-opacity'], 0.5);
+      expect(json.containsKey('fill-outline-color'), isFalse);
+    });
+
+    test('fromJson roundtrip', () {
+      const original = FillLayerProperties(
+        fillColor: '#00FF00',
+        fillOpacity: 0.5,
+        fillOutlineColor: '#000000',
+        visibility: 'none',
+      );
+      final restored = FillLayerProperties.fromJson(original.toJson());
+      expect(restored.fillColor, '#00FF00');
+      expect(restored.fillOpacity, 0.5);
+      expect(restored.fillOutlineColor, '#000000');
+      expect(restored.visibility, 'none');
+    });
+  });
+
+  group('SymbolLayerProperties', () {
+    test('toJson with skipNulls', () {
+      const props = SymbolLayerProperties(
+        iconImage: 'marker',
+        iconSize: 1.5,
+        textField: 'Hello',
+      );
+      final json = props.toJson();
+      expect(json['icon-image'], 'marker');
+      expect(json['icon-size'], 1.5);
+      expect(json['text-field'], 'Hello');
+      expect(json.containsKey('icon-opacity'), isFalse);
+    });
+
+    test('fromJson roundtrip', () {
+      const original = SymbolLayerProperties(
+        iconImage: 'marker',
+        iconSize: 1.5,
+        textField: 'Hello',
+        textColor: '#FF0000',
+      );
+      final restored = SymbolLayerProperties.fromJson(original.toJson());
+      expect(restored.iconImage, 'marker');
+      expect(restored.iconSize, 1.5);
+      expect(restored.textField, 'Hello');
+      expect(restored.textColor, '#FF0000');
+    });
+  });
+
+  group('FillExtrusionLayerProperties', () {
+    test('toJson with skipNulls', () {
+      const props = FillExtrusionLayerProperties(
+        fillExtrusionColor: '#333333',
+        fillExtrusionHeight: 100,
+      );
+      final json = props.toJson();
+      expect(json['fill-extrusion-color'], '#333333');
+      expect(json['fill-extrusion-height'], 100);
+    });
+
+    test('fromJson roundtrip', () {
+      const original = FillExtrusionLayerProperties(
+        fillExtrusionColor: '#333333',
+        fillExtrusionHeight: 100,
+        fillExtrusionOpacity: 0.9,
+      );
+      final restored =
+          FillExtrusionLayerProperties.fromJson(original.toJson());
+      expect(restored.fillExtrusionColor, '#333333');
+      expect(restored.fillExtrusionHeight, 100);
+      expect(restored.fillExtrusionOpacity, 0.9);
+    });
+  });
+
+  group('RasterLayerProperties', () {
+    test('toJson with skipNulls', () {
+      const props = RasterLayerProperties(
+        rasterOpacity: 0.8,
+        rasterBrightnessMax: 1.0,
+      );
+      final json = props.toJson();
+      expect(json['raster-opacity'], 0.8);
+      expect(json['raster-brightness-max'], 1.0);
+    });
+
+    test('fromJson roundtrip', () {
+      const original = RasterLayerProperties(
+        rasterOpacity: 0.8,
+        rasterSaturation: -0.5,
+      );
+      final restored = RasterLayerProperties.fromJson(original.toJson());
+      expect(restored.rasterOpacity, 0.8);
+      expect(restored.rasterSaturation, -0.5);
+    });
+  });
+
+  group('HillshadeLayerProperties', () {
+    test('toJson with skipNulls', () {
+      const props = HillshadeLayerProperties(
+        hillshadeExaggeration: 0.5,
+        hillshadeIlluminationDirection: 335,
+      );
+      final json = props.toJson();
+      expect(json['hillshade-exaggeration'], 0.5);
+      expect(json['hillshade-illumination-direction'], 335);
+    });
+
+    test('fromJson roundtrip', () {
+      const original = HillshadeLayerProperties(
+        hillshadeExaggeration: 0.5,
+        hillshadeShadowColor: '#000000',
+      );
+      final restored = HillshadeLayerProperties.fromJson(original.toJson());
+      expect(restored.hillshadeExaggeration, 0.5);
+      expect(restored.hillshadeShadowColor, '#000000');
+    });
+  });
+
+  group('HeatmapLayerProperties', () {
+    test('toJson with skipNulls', () {
+      const props = HeatmapLayerProperties(
+        heatmapRadius: 30,
+        heatmapIntensity: 0.5,
+      );
+      final json = props.toJson();
+      expect(json['heatmap-radius'], 30);
+      expect(json['heatmap-intensity'], 0.5);
+    });
+
+    test('fromJson roundtrip', () {
+      const original = HeatmapLayerProperties(
+        heatmapRadius: 30,
+        heatmapOpacity: 0.7,
+      );
+      final restored = HeatmapLayerProperties.fromJson(original.toJson());
+      expect(restored.heatmapRadius, 30);
+      expect(restored.heatmapOpacity, 0.7);
+    });
+  });
+
+  group('LayerProperties visibility', () {
+    test('all layer types support visibility', () {
+      final layers = <LayerProperties>[
+        const CircleLayerProperties(visibility: 'visible'),
+        const LineLayerProperties(visibility: 'none'),
+        const FillLayerProperties(visibility: 'visible'),
+        const SymbolLayerProperties(visibility: 'none'),
+        const FillExtrusionLayerProperties(visibility: 'visible'),
+        const RasterLayerProperties(visibility: 'none'),
+        const HillshadeLayerProperties(visibility: 'visible'),
+        const HeatmapLayerProperties(visibility: 'none'),
+      ];
+      for (final layer in layers) {
+        final json = layer.toJson();
+        expect(json.containsKey('visibility'), isTrue);
+      }
+    });
+  });
+}

--- a/maplibre_gl/test/offline_region_test.dart
+++ b/maplibre_gl/test/offline_region_test.dart
@@ -1,0 +1,171 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_gl/maplibre_gl.dart';
+
+void main() {
+  group('OfflineRegionDefinition', () {
+    final bounds = LatLngBounds(
+      southwest: const LatLng(10.0, 20.0),
+      northeast: const LatLng(30.0, 40.0),
+    );
+
+    test('basic construction', () {
+      final def = OfflineRegionDefinition(
+        bounds: bounds,
+        mapStyleUrl: 'https://example.com/style.json',
+        minZoom: 5.0,
+        maxZoom: 15.0,
+      );
+      expect(def.bounds, bounds);
+      expect(def.mapStyleUrl, 'https://example.com/style.json');
+      expect(def.minZoom, 5.0);
+      expect(def.maxZoom, 15.0);
+      expect(def.includeIdeographs, false); // default
+    });
+
+    test('with includeIdeographs', () {
+      final def = OfflineRegionDefinition(
+        bounds: bounds,
+        mapStyleUrl: 'https://example.com/style.json',
+        minZoom: 0.0,
+        maxZoom: 20.0,
+        includeIdeographs: true,
+      );
+      expect(def.includeIdeographs, true);
+    });
+
+    test('toMap produces correct structure', () {
+      final def = OfflineRegionDefinition(
+        bounds: bounds,
+        mapStyleUrl: 'https://example.com/style.json',
+        minZoom: 5.0,
+        maxZoom: 15.0,
+        includeIdeographs: true,
+      );
+      final map = def.toMap();
+      expect(map['bounds'], bounds.toList());
+      expect(map['mapStyleUrl'], 'https://example.com/style.json');
+      expect(map['minZoom'], 5.0);
+      expect(map['maxZoom'], 15.0);
+      expect(map['includeIdeographs'], true);
+    });
+
+    test('fromMap roundtrip', () {
+      final original = OfflineRegionDefinition(
+        bounds: bounds,
+        mapStyleUrl: 'https://example.com/style.json',
+        minZoom: 5.0,
+        maxZoom: 15.0,
+        includeIdeographs: true,
+      );
+      final restored = OfflineRegionDefinition.fromMap(original.toMap());
+      expect(restored.bounds, original.bounds);
+      expect(restored.mapStyleUrl, original.mapStyleUrl);
+      expect(restored.minZoom, original.minZoom);
+      expect(restored.maxZoom, original.maxZoom);
+      expect(restored.includeIdeographs, original.includeIdeographs);
+    });
+
+    test('fromMap handles integer zoom values', () {
+      final map = <String, dynamic>{
+        'bounds': [
+          [10.0, 20.0],
+          [30.0, 40.0],
+        ],
+        'mapStyleUrl': 'https://example.com/style.json',
+        'minZoom': 5, // int, not double
+        'maxZoom': 15, // int, not double
+        'includeIdeographs': false,
+      };
+      final def = OfflineRegionDefinition.fromMap(map);
+      expect(def.minZoom, 5.0);
+      expect(def.maxZoom, 15.0);
+    });
+
+    test('toString', () {
+      final def = OfflineRegionDefinition(
+        bounds: bounds,
+        mapStyleUrl: 'https://example.com/style.json',
+        minZoom: 5.0,
+        maxZoom: 15.0,
+      );
+      expect(def.toString(), contains('OfflineRegionDefinition'));
+      expect(def.toString(), contains('5.0'));
+    });
+  });
+
+  group('OfflineRegion', () {
+    test('fromMap constructs correctly', () {
+      final map = <String, dynamic>{
+        'id': 42,
+        'definition': {
+          'bounds': [
+            [10.0, 20.0],
+            [30.0, 40.0],
+          ],
+          'mapStyleUrl': 'https://example.com/style.json',
+          'minZoom': 5.0,
+          'maxZoom': 15.0,
+          'includeIdeographs': false,
+        },
+        'metadata': {'name': 'Test Region'},
+      };
+      final region = OfflineRegion.fromMap(map);
+      expect(region.id, 42);
+      expect(
+        region.definition.mapStyleUrl,
+        'https://example.com/style.json',
+      );
+      expect(region.metadata['name'], 'Test Region');
+    });
+
+    test('toString', () {
+      final region = OfflineRegion(
+        id: 1,
+        definition: OfflineRegionDefinition(
+          bounds: LatLngBounds(
+            southwest: const LatLng(0.0, 0.0),
+            northeast: const LatLng(1.0, 1.0),
+          ),
+          mapStyleUrl: 'https://example.com/style.json',
+          minZoom: 0.0,
+          maxZoom: 10.0,
+        ),
+        metadata: const {},
+      );
+      expect(region.toString(), contains('OfflineRegion'));
+      expect(region.toString(), contains('1'));
+    });
+  });
+
+  group('DownloadRegionStatus', () {
+    test('Success is a DownloadRegionStatus', () {
+      final status = Success();
+      expect(status, isA<DownloadRegionStatus>());
+    });
+
+    test('InProgress stores progress', () {
+      final status = InProgress(0.5);
+      expect(status, isA<DownloadRegionStatus>());
+      expect(status.progress, 0.5);
+    });
+
+    test('InProgress toString', () {
+      final status = InProgress(0.75);
+      expect(status.toString(), contains('0.75'));
+    });
+
+    test('Error stores cause', () {
+      final cause = PlatformException(code: 'ERROR', message: 'fail');
+      final status = Error(cause);
+      expect(status, isA<DownloadRegionStatus>());
+      expect(status.cause, cause);
+    });
+
+    test('Error toString', () {
+      final cause = PlatformException(code: 'ERROR', message: 'fail');
+      final status = Error(cause);
+      expect(status.toString(), contains('Error'));
+    });
+  });
+}

--- a/maplibre_gl/test/offline_region_test.dart
+++ b/maplibre_gl/test/offline_region_test.dart
@@ -90,7 +90,7 @@ void main() {
         maxZoom: 15.0,
       );
       expect(def.toString(), contains('OfflineRegionDefinition'));
-      expect(def.toString(), contains('5.0'));
+      expect(def.toString(), contains('minZoom = 5'));
     });
   });
 

--- a/maplibre_gl/test/util_test.dart
+++ b/maplibre_gl/test/util_test.dart
@@ -20,8 +20,14 @@ void main() {
 
     test('multiple features', () {
       final features = [
-        {'type': 'Feature', 'properties': {'id': '1'}},
-        {'type': 'Feature', 'properties': {'id': '2'}},
+        {
+          'type': 'Feature',
+          'properties': {'id': '1'},
+        },
+        {
+          'type': 'Feature',
+          'properties': {'id': '2'},
+        },
       ];
       final result = buildFeatureCollection(features);
       expect((result['features'] as List).length, 2);

--- a/maplibre_gl/test/util_test.dart
+++ b/maplibre_gl/test/util_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_gl/maplibre_gl.dart';
+
+void main() {
+  group('buildFeatureCollection', () {
+    test('wraps features in FeatureCollection', () {
+      final features = [
+        {'type': 'Feature', 'geometry': null, 'properties': {}},
+      ];
+      final result = buildFeatureCollection(features);
+      expect(result['type'], 'FeatureCollection');
+      expect(result['features'], features);
+    });
+
+    test('empty list produces empty FeatureCollection', () {
+      final result = buildFeatureCollection([]);
+      expect(result['type'], 'FeatureCollection');
+      expect(result['features'], isEmpty);
+    });
+
+    test('multiple features', () {
+      final features = [
+        {'type': 'Feature', 'properties': {'id': '1'}},
+        {'type': 'Feature', 'properties': {'id': '2'}},
+      ];
+      final result = buildFeatureCollection(features);
+      expect((result['features'] as List).length, 2);
+    });
+  });
+
+  group('getRandomString', () {
+    test('default length is 10', () {
+      final result = getRandomString();
+      expect(result.length, 10);
+    });
+
+    test('custom length', () {
+      expect(getRandomString(5).length, 5);
+      expect(getRandomString(20).length, 20);
+    });
+
+    test('produces different strings', () {
+      final a = getRandomString();
+      final b = getRandomString();
+      // Statistically extremely unlikely to be equal
+      expect(a, isNot(equals(b)));
+    });
+
+    test('contains only alphanumeric characters', () {
+      final result = getRandomString(100);
+      expect(
+        result,
+        matches(RegExp(r'^[A-Za-z0-9]+$')),
+      );
+    });
+  });
+}

--- a/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
+++ b/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
@@ -107,7 +107,7 @@ class MapLibreMethodChannel extends MapLibrePlatform {
                       headingAccuracy: heading['headingAccuracy'],
                       x: heading['x'],
                       y: heading['y'],
-                      z: heading['x'],
+                      z: heading['z'],
                       timestamp: DateTime.fromMillisecondsSinceEpoch(
                         heading['timestamp'],
                       ),

--- a/maplibre_gl_platform_interface/test/annotation_options_test.dart
+++ b/maplibre_gl_platform_interface/test/annotation_options_test.dart
@@ -1,0 +1,392 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_gl_platform_interface/maplibre_gl_platform_interface.dart';
+
+void main() {
+  group('SymbolOptions', () {
+    test('default options produce empty json', () {
+      final json = SymbolOptions.defaultOptions.toJson() as Map<String, dynamic>;
+      expect(json, isEmpty);
+    });
+
+    test('toJson includes non-null fields', () {
+      const options = SymbolOptions(
+        iconSize: 1.5,
+        iconImage: 'marker',
+        iconRotate: 45.0,
+        textField: 'Hello',
+        textSize: 14.0,
+        geometry: LatLng(10.0, 20.0),
+        draggable: true,
+      );
+      final json = options.toJson() as Map<String, dynamic>;
+      expect(json['iconSize'], 1.5);
+      expect(json['iconImage'], 'marker');
+      expect(json['iconRotate'], 45.0);
+      expect(json['textField'], 'Hello');
+      expect(json['textSize'], 14.0);
+      expect(json['geometry'], [10.0, 20.0]);
+      expect(json['draggable'], true);
+    });
+
+    test('toJson with addGeometry=false excludes geometry', () {
+      const options = SymbolOptions(
+        iconSize: 1.5,
+        geometry: LatLng(10.0, 20.0),
+      );
+      final json = options.toJson(false) as Map<String, dynamic>;
+      expect(json.containsKey('geometry'), isFalse);
+      expect(json['iconSize'], 1.5);
+    });
+
+    test('toJson serializes iconOffset and textOffset', () {
+      const options = SymbolOptions(
+        iconOffset: Offset(5.0, 10.0),
+        textOffset: Offset(3.0, 7.0),
+      );
+      final json = options.toJson() as Map<String, dynamic>;
+      expect(json['iconOffset'], [5.0, 10.0]);
+      expect(json['textOffset'], [3.0, 7.0]);
+    });
+
+    test('copyWith merges changes', () {
+      const original = SymbolOptions(iconSize: 1.0, textField: 'A');
+      final merged = original.copyWith(const SymbolOptions(iconSize: 2.0));
+      expect(merged.iconSize, 2.0);
+      expect(merged.textField, 'A'); // preserved
+    });
+
+    test('toGeoJson produces valid GeoJSON Feature with Point', () {
+      const options = SymbolOptions(
+        iconSize: 1.5,
+        geometry: LatLng(10.0, 20.0),
+      );
+      final geojson = options.toGeoJson();
+      expect(geojson['type'], 'Feature');
+      expect(geojson['geometry']['type'], 'Point');
+      // GeoJSON coordinates are [lng, lat]
+      expect(geojson['geometry']['coordinates'], [20.0, 10.0]);
+      // properties should not contain geometry
+      expect(
+        (geojson['properties'] as Map).containsKey('geometry'),
+        isFalse,
+      );
+    });
+  });
+
+  group('Symbol', () {
+    test('toGeoJson includes id', () {
+      final symbol = Symbol(
+        'sym-1',
+        const SymbolOptions(geometry: LatLng(10.0, 20.0)),
+      );
+      final geojson = symbol.toGeoJson();
+      expect(geojson['id'], 'sym-1');
+      expect(geojson['properties']['id'], 'sym-1');
+    });
+
+    test('translate moves geometry', () {
+      final symbol = Symbol(
+        'sym-1',
+        const SymbolOptions(geometry: LatLng(10.0, 20.0)),
+      );
+      symbol.translate(const LatLng(1.0, 2.0));
+      expect(symbol.options.geometry!.latitude, 11.0);
+      expect(symbol.options.geometry!.longitude, 22.0);
+    });
+
+    test('data property', () {
+      final symbol = Symbol(
+        'sym-1',
+        SymbolOptions.defaultOptions,
+        {'key': 'value'},
+      );
+      expect(symbol.data, {'key': 'value'});
+    });
+  });
+
+  group('CircleOptions', () {
+    test('default options produce empty json', () {
+      final json = CircleOptions.defaultOptions.toJson() as Map<String, dynamic>;
+      expect(json, isEmpty);
+    });
+
+    test('toJson includes non-null fields', () {
+      const options = CircleOptions(
+        circleRadius: 10.0,
+        circleColor: '#FF0000',
+        circleOpacity: 0.8,
+        geometry: LatLng(10.0, 20.0),
+        draggable: false,
+      );
+      final json = options.toJson() as Map<String, dynamic>;
+      expect(json['circleRadius'], 10.0);
+      expect(json['circleColor'], '#FF0000');
+      expect(json['circleOpacity'], 0.8);
+      expect(json['geometry'], [10.0, 20.0]);
+      expect(json['draggable'], false);
+    });
+
+    test('toJson with addGeometry=false excludes geometry', () {
+      const options = CircleOptions(
+        circleRadius: 10.0,
+        geometry: LatLng(10.0, 20.0),
+      );
+      final json = options.toJson(false) as Map<String, dynamic>;
+      expect(json.containsKey('geometry'), isFalse);
+    });
+
+    test('copyWith merges changes', () {
+      const original = CircleOptions(circleRadius: 10.0, circleColor: '#000');
+      final merged =
+          original.copyWith(const CircleOptions(circleRadius: 20.0));
+      expect(merged.circleRadius, 20.0);
+      expect(merged.circleColor, '#000');
+    });
+
+    test('toGeoJson produces valid GeoJSON Feature with Point', () {
+      const options = CircleOptions(geometry: LatLng(10.0, 20.0));
+      final geojson = options.toGeoJson();
+      expect(geojson['type'], 'Feature');
+      expect(geojson['geometry']['type'], 'Point');
+      expect(geojson['geometry']['coordinates'], [20.0, 10.0]);
+    });
+  });
+
+  group('Circle', () {
+    test('toGeoJson includes id', () {
+      final circle = Circle(
+        'circle-1',
+        const CircleOptions(geometry: LatLng(10.0, 20.0)),
+      );
+      final geojson = circle.toGeoJson();
+      expect(geojson['id'], 'circle-1');
+      expect(geojson['properties']['id'], 'circle-1');
+    });
+
+    test('translate moves geometry', () {
+      final circle = Circle(
+        'circle-1',
+        const CircleOptions(geometry: LatLng(10.0, 20.0)),
+      );
+      circle.translate(const LatLng(5.0, 5.0));
+      expect(circle.options.geometry!.latitude, 15.0);
+      expect(circle.options.geometry!.longitude, 25.0);
+    });
+  });
+
+  group('LineOptions', () {
+    test('default options produce empty json', () {
+      final json = LineOptions.defaultOptions.toJson() as Map<String, dynamic>;
+      expect(json, isEmpty);
+    });
+
+    test('toJson includes non-null fields', () {
+      const options = LineOptions(
+        lineColor: '#0000FF',
+        lineWidth: 3.0,
+        lineJoin: 'round',
+        geometry: [LatLng(10.0, 20.0), LatLng(30.0, 40.0)],
+      );
+      final json = options.toJson() as Map<String, dynamic>;
+      expect(json['lineColor'], '#0000FF');
+      expect(json['lineWidth'], 3.0);
+      expect(json['lineJoin'], 'round');
+      expect(json['geometry'], isA<List>());
+    });
+
+    test('toJson serializes geometry as list of [lat, lng] pairs', () {
+      const options = LineOptions(
+        geometry: [LatLng(10.0, 20.0), LatLng(30.0, 40.0)],
+      );
+      final json = options.toJson() as Map<String, dynamic>;
+      final geometry = json['geometry'] as List;
+      expect(geometry[0], [10.0, 20.0]);
+      expect(geometry[1], [30.0, 40.0]);
+    });
+
+    test('toJson with addGeometry=false excludes geometry', () {
+      const options = LineOptions(
+        lineWidth: 2.0,
+        geometry: [LatLng(10.0, 20.0)],
+      );
+      final json = options.toJson(false) as Map<String, dynamic>;
+      expect(json.containsKey('geometry'), isFalse);
+    });
+
+    test('copyWith merges changes', () {
+      const original = LineOptions(lineWidth: 2.0, lineColor: '#000');
+      final merged = original.copyWith(const LineOptions(lineWidth: 5.0));
+      expect(merged.lineWidth, 5.0);
+      expect(merged.lineColor, '#000');
+    });
+
+    test('toGeoJson produces valid GeoJSON Feature with LineString', () {
+      const options = LineOptions(
+        geometry: [LatLng(10.0, 20.0), LatLng(30.0, 40.0)],
+      );
+      final geojson = options.toGeoJson();
+      expect(geojson['type'], 'Feature');
+      expect(geojson['geometry']['type'], 'LineString');
+      // GeoJSON coordinates are [lng, lat]
+      final coords = geojson['geometry']['coordinates'] as List;
+      expect(coords[0], [20.0, 10.0]);
+      expect(coords[1], [40.0, 30.0]);
+    });
+  });
+
+  group('Line', () {
+    test('toGeoJson includes id', () {
+      final line = Line(
+        'line-1',
+        const LineOptions(
+          geometry: [LatLng(10.0, 20.0), LatLng(30.0, 40.0)],
+        ),
+      );
+      final geojson = line.toGeoJson();
+      expect(geojson['id'], 'line-1');
+      expect(geojson['properties']['id'], 'line-1');
+    });
+
+    test('translate moves all geometry points', () {
+      final line = Line(
+        'line-1',
+        const LineOptions(
+          geometry: [LatLng(10.0, 20.0), LatLng(30.0, 40.0)],
+        ),
+      );
+      line.translate(const LatLng(1.0, 2.0));
+      expect(line.options.geometry![0], const LatLng(11.0, 22.0));
+      expect(line.options.geometry![1], const LatLng(31.0, 42.0));
+    });
+  });
+
+  group('FillOptions', () {
+    test('default options produce empty json', () {
+      final json = FillOptions.defaultOptions.toJson() as Map<String, dynamic>;
+      expect(json, isEmpty);
+    });
+
+    test('toJson includes non-null fields', () {
+      const options = FillOptions(
+        fillOpacity: 0.5,
+        fillColor: '#00FF00',
+        fillOutlineColor: '#000000',
+        draggable: true,
+      );
+      final json = options.toJson() as Map<String, dynamic>;
+      expect(json['fillOpacity'], 0.5);
+      expect(json['fillColor'], '#00FF00');
+      expect(json['fillOutlineColor'], '#000000');
+      expect(json['draggable'], true);
+    });
+
+    test('toJson serializes nested geometry correctly', () {
+      const options = FillOptions(
+        geometry: [
+          [LatLng(0.0, 0.0), LatLng(10.0, 0.0), LatLng(10.0, 10.0)],
+        ],
+      );
+      final json = options.toJson() as Map<String, dynamic>;
+      final geometry = json['geometry'] as List;
+      expect(geometry.length, 1);
+      final ring = geometry[0] as List;
+      expect(ring[0], [0.0, 0.0]);
+      expect(ring[1], [10.0, 0.0]);
+    });
+
+    test('toJson with addGeometry=false excludes geometry', () {
+      const options = FillOptions(
+        fillOpacity: 0.5,
+        geometry: [
+          [LatLng(0.0, 0.0)],
+        ],
+      );
+      final json = options.toJson(false) as Map<String, dynamic>;
+      expect(json.containsKey('geometry'), isFalse);
+    });
+
+    test('copyWith merges changes', () {
+      const original = FillOptions(fillOpacity: 0.5, fillColor: '#000');
+      final merged = original.copyWith(const FillOptions(fillOpacity: 0.8));
+      expect(merged.fillOpacity, 0.8);
+      expect(merged.fillColor, '#000');
+    });
+
+    test('toGeoJson produces valid GeoJSON Feature with Polygon', () {
+      const options = FillOptions(
+        geometry: [
+          [LatLng(0.0, 0.0), LatLng(10.0, 0.0), LatLng(10.0, 10.0)],
+        ],
+      );
+      final geojson = options.toGeoJson();
+      expect(geojson['type'], 'Feature');
+      expect(geojson['geometry']['type'], 'Polygon');
+      // GeoJSON coordinates are [lng, lat]
+      final coords = geojson['geometry']['coordinates'] as List;
+      final ring = coords[0] as List;
+      expect(ring[0], [0.0, 0.0]);
+      expect(ring[1], [0.0, 10.0]); // [lng=0, lat=10]
+    });
+  });
+
+  group('Fill', () {
+    test('toGeoJson includes id', () {
+      final fill = Fill(
+        'fill-1',
+        const FillOptions(
+          geometry: [
+            [LatLng(0.0, 0.0), LatLng(10.0, 0.0), LatLng(10.0, 10.0)],
+          ],
+        ),
+      );
+      final geojson = fill.toGeoJson();
+      expect(geojson['id'], 'fill-1');
+      expect(geojson['properties']['id'], 'fill-1');
+    });
+
+    test('translate moves all geometry points in all rings', () {
+      final fill = Fill(
+        'fill-1',
+        const FillOptions(
+          geometry: [
+            [LatLng(0.0, 0.0), LatLng(10.0, 0.0), LatLng(10.0, 10.0)],
+          ],
+        ),
+      );
+      fill.translate(const LatLng(1.0, 2.0));
+      expect(fill.options.geometry![0][0], const LatLng(1.0, 2.0));
+      expect(fill.options.geometry![0][1], const LatLng(11.0, 2.0));
+      expect(fill.options.geometry![0][2], const LatLng(11.0, 12.0));
+    });
+
+    test('translate with null geometry returns same options', () {
+      final fill = Fill('fill-1', const FillOptions(fillOpacity: 0.5));
+      fill.translate(const LatLng(1.0, 2.0));
+      expect(fill.options.fillOpacity, 0.5);
+      expect(fill.options.geometry, isNull);
+    });
+  });
+
+  group('translateFillOptions', () {
+    test('translates all rings', () {
+      const options = FillOptions(
+        geometry: [
+          [LatLng(0.0, 0.0), LatLng(10.0, 0.0)],
+          [LatLng(2.0, 2.0), LatLng(5.0, 5.0)],
+        ],
+      );
+      final translated =
+          translateFillOptions(options, const LatLng(1.0, 1.0));
+      expect(translated.geometry![0][0], const LatLng(1.0, 1.0));
+      expect(translated.geometry![0][1], const LatLng(11.0, 1.0));
+      expect(translated.geometry![1][0], const LatLng(3.0, 3.0));
+      expect(translated.geometry![1][1], const LatLng(6.0, 6.0));
+    });
+
+    test('returns same options when geometry is null', () {
+      const options = FillOptions(fillOpacity: 0.5);
+      final result = translateFillOptions(options, const LatLng(1.0, 1.0));
+      expect(identical(result, options), isTrue);
+    });
+  });
+}

--- a/maplibre_gl_platform_interface/test/annotation_options_test.dart
+++ b/maplibre_gl_platform_interface/test/annotation_options_test.dart
@@ -4,7 +4,8 @@ import 'package:maplibre_gl_platform_interface/maplibre_gl_platform_interface.da
 void main() {
   group('SymbolOptions', () {
     test('default options produce empty json', () {
-      final json = SymbolOptions.defaultOptions.toJson() as Map<String, dynamic>;
+      final json =
+          SymbolOptions.defaultOptions.toJson() as Map<String, dynamic>;
       expect(json, isEmpty);
     });
 
@@ -106,7 +107,8 @@ void main() {
 
   group('CircleOptions', () {
     test('default options produce empty json', () {
-      final json = CircleOptions.defaultOptions.toJson() as Map<String, dynamic>;
+      final json =
+          CircleOptions.defaultOptions.toJson() as Map<String, dynamic>;
       expect(json, isEmpty);
     });
 
@@ -137,8 +139,7 @@ void main() {
 
     test('copyWith merges changes', () {
       const original = CircleOptions(circleRadius: 10.0, circleColor: '#000');
-      final merged =
-          original.copyWith(const CircleOptions(circleRadius: 20.0));
+      final merged = original.copyWith(const CircleOptions(circleRadius: 20.0));
       expect(merged.circleRadius, 20.0);
       expect(merged.circleColor, '#000');
     });
@@ -375,8 +376,7 @@ void main() {
           [LatLng(2.0, 2.0), LatLng(5.0, 5.0)],
         ],
       );
-      final translated =
-          translateFillOptions(options, const LatLng(1.0, 1.0));
+      final translated = translateFillOptions(options, const LatLng(1.0, 1.0));
       expect(translated.geometry![0][0], const LatLng(1.0, 1.0));
       expect(translated.geometry![0][1], const LatLng(11.0, 1.0));
       expect(translated.geometry![1][0], const LatLng(3.0, 3.0));

--- a/maplibre_gl_platform_interface/test/callbacks_test.dart
+++ b/maplibre_gl_platform_interface/test/callbacks_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_gl_platform_interface/maplibre_gl_platform_interface.dart';
+
+void main() {
+  group('ArgumentCallbacks', () {
+    test('starts empty', () {
+      final callbacks = ArgumentCallbacks<int>();
+      expect(callbacks.isEmpty, isTrue);
+      expect(callbacks.isNotEmpty, isFalse);
+    });
+
+    test('add makes it non-empty', () {
+      final callbacks = ArgumentCallbacks<int>();
+      callbacks.add((_) {});
+      expect(callbacks.isEmpty, isFalse);
+      expect(callbacks.isNotEmpty, isTrue);
+    });
+
+    test('call invokes a single callback', () {
+      final callbacks = ArgumentCallbacks<int>();
+      int? received;
+      callbacks.add((value) => received = value);
+
+      callbacks.call(42);
+      expect(received, 42);
+    });
+
+    test('call invokes multiple callbacks', () {
+      final callbacks = ArgumentCallbacks<int>();
+      final results = <int>[];
+
+      callbacks.add((value) => results.add(value * 1));
+      callbacks.add((value) => results.add(value * 2));
+      callbacks.add((value) => results.add(value * 3));
+
+      callbacks.call(10);
+      expect(results, [10, 20, 30]);
+    });
+
+    test('remove stops callback from being invoked', () {
+      final callbacks = ArgumentCallbacks<int>();
+      var callCount = 0;
+      void callback(int _) => callCount++;
+
+      callbacks.add(callback);
+      callbacks.call(1);
+      expect(callCount, 1);
+
+      callbacks.remove(callback);
+      callbacks.call(2);
+      expect(callCount, 1); // not called again
+    });
+
+    test('remove non-existent callback does nothing', () {
+      final callbacks = ArgumentCallbacks<int>();
+      callbacks.add((_) {});
+      callbacks.remove((_) {}); // different closure
+      expect(callbacks.isNotEmpty, isTrue);
+    });
+
+    test('clear removes all callbacks', () {
+      final callbacks = ArgumentCallbacks<int>();
+      callbacks.add((_) {});
+      callbacks.add((_) {});
+      callbacks.clear();
+      expect(callbacks.isEmpty, isTrue);
+    });
+
+    test('call with zero callbacks does not throw', () {
+      final callbacks = ArgumentCallbacks<int>();
+      expect(() => callbacks.call(42), returnsNormally);
+    });
+
+    test('call snapshots list to handle modification during iteration', () {
+      final callbacks = ArgumentCallbacks<int>();
+      final results = <int>[];
+
+      callbacks.add((value) {
+        results.add(1);
+        // Modifying during iteration should not affect current call
+        callbacks.add((v) => results.add(99));
+      });
+      callbacks.add((value) => results.add(2));
+
+      callbacks.call(0);
+      // Only the original 2 callbacks should run
+      expect(results, [1, 2]);
+    });
+  });
+}

--- a/maplibre_gl_platform_interface/test/camera_test.dart
+++ b/maplibre_gl_platform_interface/test/camera_test.dart
@@ -124,8 +124,7 @@ void main() {
     });
 
     test('newLatLngZoom', () {
-      final update =
-          CameraUpdate.newLatLngZoom(const LatLng(10.0, 20.0), 12.0);
+      final update = CameraUpdate.newLatLngZoom(const LatLng(10.0, 20.0), 12.0);
       final json = update.toJson() as List;
       expect(json[0], 'newLatLngZoom');
       expect(json[1], [10.0, 20.0]);

--- a/maplibre_gl_platform_interface/test/camera_test.dart
+++ b/maplibre_gl_platform_interface/test/camera_test.dart
@@ -1,0 +1,290 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_gl_platform_interface/maplibre_gl_platform_interface.dart';
+
+void main() {
+  group('CameraPosition', () {
+    test('basic construction with defaults', () {
+      const camera = CameraPosition(target: LatLng(45.0, 90.0));
+      expect(camera.bearing, 0.0);
+      expect(camera.target, const LatLng(45.0, 90.0));
+      expect(camera.tilt, 0.0);
+      expect(camera.zoom, 0.0);
+    });
+
+    test('construction with all parameters', () {
+      const camera = CameraPosition(
+        bearing: 45.0,
+        target: LatLng(10.0, 20.0),
+        tilt: 30.0,
+        zoom: 15.0,
+      );
+      expect(camera.bearing, 45.0);
+      expect(camera.target, const LatLng(10.0, 20.0));
+      expect(camera.tilt, 30.0);
+      expect(camera.zoom, 15.0);
+    });
+
+    test('toMap produces correct structure', () {
+      const camera = CameraPosition(
+        bearing: 45.0,
+        target: LatLng(10.0, 20.0),
+        tilt: 30.0,
+        zoom: 15.0,
+      );
+      final map = camera.toMap() as Map<String, dynamic>;
+      expect(map['bearing'], 45.0);
+      expect(map['target'], [10.0, 20.0]);
+      expect(map['tilt'], 30.0);
+      expect(map['zoom'], 15.0);
+    });
+
+    test('fromMap roundtrip', () {
+      const original = CameraPosition(
+        bearing: 45.0,
+        target: LatLng(10.0, 20.0),
+        tilt: 30.0,
+        zoom: 15.0,
+      );
+      final restored = CameraPosition.fromMap(original.toMap());
+      expect(restored, original);
+    });
+
+    test('fromMap with null returns null', () {
+      expect(CameraPosition.fromMap(null), isNull);
+    });
+
+    test('equality', () {
+      const a = CameraPosition(
+        bearing: 45.0,
+        target: LatLng(10.0, 20.0),
+        tilt: 30.0,
+        zoom: 15.0,
+      );
+      const b = CameraPosition(
+        bearing: 45.0,
+        target: LatLng(10.0, 20.0),
+        tilt: 30.0,
+        zoom: 15.0,
+      );
+      const c = CameraPosition(
+        bearing: 90.0,
+        target: LatLng(10.0, 20.0),
+        tilt: 30.0,
+        zoom: 15.0,
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(equals(c)));
+    });
+
+    test('toString', () {
+      const camera = CameraPosition(target: LatLng(10.0, 20.0), zoom: 5.0);
+      expect(camera.toString(), contains('CameraPosition'));
+      expect(camera.toString(), contains('10.0'));
+    });
+  });
+
+  group('CameraUpdate', () {
+    test('newCameraPosition', () {
+      const camera = CameraPosition(
+        target: LatLng(10.0, 20.0),
+        zoom: 5.0,
+      );
+      final update = CameraUpdate.newCameraPosition(camera);
+      final json = update.toJson() as List;
+      expect(json[0], 'newCameraPosition');
+      expect(json[1], isA<Map>());
+    });
+
+    test('newLatLng', () {
+      final update = CameraUpdate.newLatLng(const LatLng(10.0, 20.0));
+      final json = update.toJson() as List;
+      expect(json[0], 'newLatLng');
+      expect(json[1], [10.0, 20.0]);
+    });
+
+    test('newLatLngBounds', () {
+      final bounds = LatLngBounds(
+        southwest: const LatLng(10.0, 20.0),
+        northeast: const LatLng(30.0, 40.0),
+      );
+      final update = CameraUpdate.newLatLngBounds(
+        bounds,
+        left: 10,
+        top: 20,
+        right: 30,
+        bottom: 40,
+      );
+      final json = update.toJson() as List;
+      expect(json[0], 'newLatLngBounds');
+      expect(json[2], 10.0); // left
+      expect(json[3], 20.0); // top
+      expect(json[4], 30.0); // right
+      expect(json[5], 40.0); // bottom
+    });
+
+    test('newLatLngZoom', () {
+      final update =
+          CameraUpdate.newLatLngZoom(const LatLng(10.0, 20.0), 12.0);
+      final json = update.toJson() as List;
+      expect(json[0], 'newLatLngZoom');
+      expect(json[1], [10.0, 20.0]);
+      expect(json[2], 12.0);
+    });
+
+    test('scrollBy', () {
+      final update = CameraUpdate.scrollBy(50.0, 75.0);
+      final json = update.toJson() as List;
+      expect(json[0], 'scrollBy');
+      expect(json[1], 50.0);
+      expect(json[2], 75.0);
+    });
+
+    test('zoomBy without focus', () {
+      final update = CameraUpdate.zoomBy(2.0);
+      final json = update.toJson() as List;
+      expect(json[0], 'zoomBy');
+      expect(json[1], 2.0);
+      expect(json.length, 2);
+    });
+
+    test('zoomBy with focus', () {
+      final update = CameraUpdate.zoomBy(2.0, const Offset(100.0, 200.0));
+      final json = update.toJson() as List;
+      expect(json[0], 'zoomBy');
+      expect(json[1], 2.0);
+      expect(json[2], [100.0, 200.0]);
+    });
+
+    test('zoomIn', () {
+      final update = CameraUpdate.zoomIn();
+      final json = update.toJson() as List;
+      expect(json[0], 'zoomIn');
+    });
+
+    test('zoomOut', () {
+      final update = CameraUpdate.zoomOut();
+      final json = update.toJson() as List;
+      expect(json[0], 'zoomOut');
+    });
+
+    test('zoomTo', () {
+      final update = CameraUpdate.zoomTo(10.0);
+      final json = update.toJson() as List;
+      expect(json[0], 'zoomTo');
+      expect(json[1], 10.0);
+    });
+
+    test('bearingTo', () {
+      final update = CameraUpdate.bearingTo(90.0);
+      final json = update.toJson() as List;
+      expect(json[0], 'bearingTo');
+      expect(json[1], 90.0);
+    });
+
+    test('tiltTo', () {
+      final update = CameraUpdate.tiltTo(60.0);
+      final json = update.toJson() as List;
+      expect(json[0], 'tiltTo');
+      expect(json[1], 60.0);
+    });
+  });
+
+  group('CameraTargetBounds', () {
+    test('with bounds', () {
+      final bounds = LatLngBounds(
+        southwest: const LatLng(10.0, 20.0),
+        northeast: const LatLng(30.0, 40.0),
+      );
+      final ctb = CameraTargetBounds(bounds);
+      expect(ctb.bounds, bounds);
+    });
+
+    test('unbounded', () {
+      expect(CameraTargetBounds.unbounded.bounds, isNull);
+    });
+
+    test('toJson with bounds', () {
+      final bounds = LatLngBounds(
+        southwest: const LatLng(10.0, 20.0),
+        northeast: const LatLng(30.0, 40.0),
+      );
+      final json = CameraTargetBounds(bounds).toJson() as List;
+      expect(json.length, 1);
+      expect(json[0], isNotNull);
+    });
+
+    test('toJson unbounded', () {
+      final json = CameraTargetBounds.unbounded.toJson() as List;
+      expect(json[0], isNull);
+    });
+
+    test('equality', () {
+      final bounds = LatLngBounds(
+        southwest: const LatLng(10.0, 20.0),
+        northeast: const LatLng(30.0, 40.0),
+      );
+      final a = CameraTargetBounds(bounds);
+      final b = CameraTargetBounds(bounds);
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('toString', () {
+      expect(
+        CameraTargetBounds.unbounded.toString(),
+        contains('CameraTargetBounds'),
+      );
+    });
+  });
+
+  group('MinMaxZoomPreference', () {
+    test('basic construction', () {
+      const pref = MinMaxZoomPreference(3.0, 18.0);
+      expect(pref.minZoom, 3.0);
+      expect(pref.maxZoom, 18.0);
+    });
+
+    test('unbounded', () {
+      expect(MinMaxZoomPreference.unbounded.minZoom, isNull);
+      expect(MinMaxZoomPreference.unbounded.maxZoom, isNull);
+    });
+
+    test('asserts minZoom <= maxZoom', () {
+      expect(
+        () => MinMaxZoomPreference(20.0, 10.0),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('allows null min or max', () {
+      const onlyMin = MinMaxZoomPreference(5.0, null);
+      expect(onlyMin.minZoom, 5.0);
+      expect(onlyMin.maxZoom, isNull);
+
+      const onlyMax = MinMaxZoomPreference(null, 15.0);
+      expect(onlyMax.minZoom, isNull);
+      expect(onlyMax.maxZoom, 15.0);
+    });
+
+    test('toJson', () {
+      const pref = MinMaxZoomPreference(3.0, 18.0);
+      final json = pref.toJson() as List;
+      expect(json, [3.0, 18.0]);
+    });
+
+    test('equality', () {
+      const a = MinMaxZoomPreference(3.0, 18.0);
+      const b = MinMaxZoomPreference(3.0, 18.0);
+      const c = MinMaxZoomPreference(3.0, 20.0);
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(equals(c)));
+    });
+
+    test('toString', () {
+      const pref = MinMaxZoomPreference(3.0, 18.0);
+      expect(pref.toString(), contains('MinMaxZoomPreference'));
+    });
+  });
+}

--- a/maplibre_gl_platform_interface/test/camera_test.dart
+++ b/maplibre_gl_platform_interface/test/camera_test.dart
@@ -80,7 +80,8 @@ void main() {
     test('toString', () {
       const camera = CameraPosition(target: LatLng(10.0, 20.0), zoom: 5.0);
       expect(camera.toString(), contains('CameraPosition'));
-      expect(camera.toString(), contains('10.0'));
+      // Use regex to handle JS printing "10" vs VM printing "10.0"
+      expect(camera.toString(), matches(RegExp(r'10\.?0?')));
     });
   });
 

--- a/maplibre_gl_platform_interface/test/location_engine_properties_test.dart
+++ b/maplibre_gl_platform_interface/test/location_engine_properties_test.dart
@@ -2,9 +2,103 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:maplibre_gl_platform_interface/maplibre_gl_platform_interface.dart';
 
 void main() {
-  group(LocationEnginePlatforms, () {
+  group('LocationEngineAndroidProperties', () {
+    test('default values', () {
+      const props = LocationEngineAndroidProperties.defaultProperties;
+      expect(props.interval, 1000);
+      expect(props.displacement, 0);
+      expect(props.priority, LocationPriority.balanced);
+    });
+
+    test('toList produces [interval, priority.index, displacement]', () {
+      const props = LocationEngineAndroidProperties.defaultProperties;
+      final list = props.toList();
+      expect(list, [1000, LocationPriority.balanced.index, 0]);
+    });
+
+    test('toList with custom values', () {
+      const props = LocationEngineAndroidProperties(
+        interval: 500,
+        displacement: 10,
+        priority: LocationPriority.highAccuracy,
+      );
+      final list = props.toList();
+      expect(list, [500, LocationPriority.highAccuracy.index, 10]);
+    });
+
+    test('copyWith replaces specified fields', () {
+      const original = LocationEngineAndroidProperties.defaultProperties;
+      final updated = original.copyWith(interval: 2000);
+      expect(updated.interval, 2000);
+      expect(updated.displacement, 0); // preserved
+      expect(updated.priority, LocationPriority.balanced); // preserved
+    });
+
+    test('copyWith with all fields', () {
+      const original = LocationEngineAndroidProperties.defaultProperties;
+      final updated = original.copyWith(
+        interval: 500,
+        displacement: 50,
+        priority: LocationPriority.lowPower,
+      );
+      expect(updated.interval, 500);
+      expect(updated.displacement, 50);
+      expect(updated.priority, LocationPriority.lowPower);
+    });
+
+    test('equality', () {
+      const a = LocationEngineAndroidProperties.defaultProperties;
+      const b = LocationEngineAndroidProperties.defaultProperties;
+      const c = LocationEngineAndroidProperties(
+        interval: 500,
+        displacement: 0,
+        priority: LocationPriority.balanced,
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(equals(c)));
+    });
+
+    test('toString', () {
+      const props = LocationEngineAndroidProperties.defaultProperties;
+      expect(props.toString(), contains('LocationEngineAndroidProperties'));
+      expect(props.toString(), contains('1000'));
+    });
+  });
+
+  group('LocationEnginePlatforms', () {
     test('defaultPlatform.toList() works on all platforms', () {
       expect(LocationEnginePlatforms.defaultPlatform.toList(), isList);
+    });
+
+    test('default uses defaultProperties for android', () {
+      const platforms = LocationEnginePlatforms.defaultPlatform;
+      expect(
+        platforms.androidPlatform,
+        LocationEngineAndroidProperties.defaultProperties,
+      );
+    });
+
+    test('custom android properties', () {
+      const custom = LocationEnginePlatforms(
+        androidPlatform: LocationEngineAndroidProperties(
+          interval: 500,
+          displacement: 10,
+          priority: LocationPriority.highAccuracy,
+        ),
+      );
+      expect(custom.androidPlatform.interval, 500);
+      expect(custom.androidPlatform.displacement, 10);
+    });
+  });
+
+  group('LocationPriority', () {
+    test('enum values exist', () {
+      expect(LocationPriority.values.length, 4);
+      expect(LocationPriority.highAccuracy.index, 0);
+      expect(LocationPriority.balanced.index, 1);
+      expect(LocationPriority.lowPower.index, 2);
+      expect(LocationPriority.noPower.index, 3);
     });
   });
 }

--- a/maplibre_gl_platform_interface/test/location_test.dart
+++ b/maplibre_gl_platform_interface/test/location_test.dart
@@ -1,0 +1,328 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_gl_platform_interface/maplibre_gl_platform_interface.dart';
+
+void main() {
+  group('LatLng', () {
+    test('basic construction', () {
+      const latLng = LatLng(45.0, 90.0);
+      expect(latLng.latitude, 45.0);
+      expect(latLng.longitude, 90.0);
+    });
+
+    test('clamps latitude to [-90, 90]', () {
+      const tooHigh = LatLng(100.0, 0.0);
+      expect(tooHigh.latitude, 90.0);
+
+      const tooLow = LatLng(-100.0, 0.0);
+      expect(tooLow.latitude, -90.0);
+    });
+
+    test('latitude at exact boundaries', () {
+      const atMax = LatLng(90.0, 0.0);
+      expect(atMax.latitude, 90.0);
+
+      const atMin = LatLng(-90.0, 0.0);
+      expect(atMin.latitude, -90.0);
+    });
+
+    test('normalizes longitude to [-180, 180)', () {
+      const wrapped = LatLng(0.0, 200.0);
+      expect(wrapped.longitude, closeTo(-160.0, 1e-10));
+
+      const wrappedNeg = LatLng(0.0, -200.0);
+      expect(wrappedNeg.longitude, closeTo(160.0, 1e-10));
+    });
+
+    test('longitude at boundaries', () {
+      const atMin = LatLng(0.0, -180.0);
+      expect(atMin.longitude, -180.0);
+
+      // 180.0 wraps to -180.0
+      const atMax = LatLng(0.0, 180.0);
+      expect(atMax.longitude, -180.0);
+    });
+
+    test('longitude wrapping beyond 360', () {
+      const wrapped = LatLng(0.0, 540.0);
+      expect(wrapped.longitude, -180.0);
+    });
+
+    test('toJson produces [lat, lng]', () {
+      const latLng = LatLng(10.0, 20.0);
+      final json = latLng.toJson() as List<double>;
+      expect(json, [10.0, 20.0]);
+    });
+
+    test('toGeoJsonCoordinates produces [lng, lat] (reversed order)', () {
+      const latLng = LatLng(10.0, 20.0);
+      final coords = latLng.toGeoJsonCoordinates() as List<double>;
+      expect(coords, [20.0, 10.0]);
+    });
+
+    test('operator + adds coordinates', () {
+      const a = LatLng(10.0, 20.0);
+      const b = LatLng(5.0, 10.0);
+      final result = a + b;
+      expect(result.latitude, 15.0);
+      expect(result.longitude, 30.0);
+    });
+
+    test('operator - subtracts coordinates', () {
+      const a = LatLng(10.0, 20.0);
+      const b = LatLng(5.0, 10.0);
+      final result = a - b;
+      expect(result.latitude, 5.0);
+      expect(result.longitude, 10.0);
+    });
+
+    test('operator + clamps and normalizes result', () {
+      const a = LatLng(80.0, 170.0);
+      const b = LatLng(20.0, 20.0);
+      final result = a + b;
+      expect(result.latitude, 90.0); // clamped
+      expect(result.longitude, closeTo(-170.0, 1e-10)); // normalized
+    });
+
+    test('equality', () {
+      const a = LatLng(45.0, 90.0);
+      const b = LatLng(45.0, 90.0);
+      const c = LatLng(45.0, 91.0);
+
+      expect(a, equals(b));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('hashCode consistency', () {
+      const a = LatLng(45.0, 90.0);
+      const b = LatLng(45.0, 90.0);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('toString', () {
+      const latLng = LatLng(45.0, 90.0);
+      expect(latLng.toString(), 'LatLng(45.0, 90.0)');
+    });
+  });
+
+  group('LatLngBounds', () {
+    test('basic construction', () {
+      final bounds = LatLngBounds(
+        southwest: const LatLng(10.0, 20.0),
+        northeast: const LatLng(30.0, 40.0),
+      );
+      expect(bounds.southwest, const LatLng(10.0, 20.0));
+      expect(bounds.northeast, const LatLng(30.0, 40.0));
+    });
+
+    test('asserts southwest.lat <= northeast.lat', () {
+      expect(
+        () => LatLngBounds(
+          southwest: const LatLng(50.0, 0.0),
+          northeast: const LatLng(10.0, 0.0),
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('toList produces [[sw.lat, sw.lng], [ne.lat, ne.lng]]', () {
+      final bounds = LatLngBounds(
+        southwest: const LatLng(10.0, 20.0),
+        northeast: const LatLng(30.0, 40.0),
+      );
+      final list = bounds.toList() as List;
+      expect(list[0], [10.0, 20.0]);
+      expect(list[1], [30.0, 40.0]);
+    });
+
+    test('fromList roundtrip', () {
+      final original = LatLngBounds(
+        southwest: const LatLng(10.0, 20.0),
+        northeast: const LatLng(30.0, 40.0),
+      );
+      final restored = LatLngBounds.fromList(original.toList());
+      expect(restored, original);
+    });
+
+    test('fromList with null returns null', () {
+      expect(LatLngBounds.fromList(null), isNull);
+    });
+
+    test('contains returns true for point inside', () {
+      final bounds = LatLngBounds(
+        southwest: const LatLng(10.0, 20.0),
+        northeast: const LatLng(30.0, 40.0),
+      );
+      expect(bounds.contains(const LatLng(20.0, 30.0)), isTrue);
+    });
+
+    test('contains returns true for point on boundary', () {
+      final bounds = LatLngBounds(
+        southwest: const LatLng(10.0, 20.0),
+        northeast: const LatLng(30.0, 40.0),
+      );
+      expect(bounds.contains(const LatLng(10.0, 20.0)), isTrue);
+      expect(bounds.contains(const LatLng(30.0, 40.0)), isTrue);
+    });
+
+    test('contains returns false for point outside', () {
+      final bounds = LatLngBounds(
+        southwest: const LatLng(10.0, 20.0),
+        northeast: const LatLng(30.0, 40.0),
+      );
+      expect(bounds.contains(const LatLng(5.0, 30.0)), isFalse);
+      expect(bounds.contains(const LatLng(20.0, 50.0)), isFalse);
+    });
+
+    test('contains handles longitude wrap-around', () {
+      // Bounds that cross the antimeridian: sw.lng > ne.lng
+      final bounds = LatLngBounds(
+        southwest: const LatLng(-10.0, 170.0),
+        northeast: const LatLng(10.0, -170.0),
+      );
+      // Point at 175 lng should be inside (between 170 and -170 wrapping)
+      expect(bounds.contains(const LatLng(0.0, 175.0)), isTrue);
+      // Point at -175 lng should be inside
+      expect(bounds.contains(const LatLng(0.0, -175.0)), isTrue);
+      // Point at 0 lng should be outside
+      expect(bounds.contains(const LatLng(0.0, 0.0)), isFalse);
+    });
+
+    test('equality', () {
+      final a = LatLngBounds(
+        southwest: const LatLng(10.0, 20.0),
+        northeast: const LatLng(30.0, 40.0),
+      );
+      final b = LatLngBounds(
+        southwest: const LatLng(10.0, 20.0),
+        northeast: const LatLng(30.0, 40.0),
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('toString', () {
+      final bounds = LatLngBounds(
+        southwest: const LatLng(10.0, 20.0),
+        northeast: const LatLng(30.0, 40.0),
+      );
+      expect(
+        bounds.toString(),
+        'LatLngBounds(LatLng(10.0, 20.0), LatLng(30.0, 40.0))',
+      );
+    });
+  });
+
+  group('LatLngQuad', () {
+    const quad = LatLngQuad(
+      topLeft: LatLng(40.0, -74.0),
+      topRight: LatLng(40.0, -73.0),
+      bottomRight: LatLng(39.0, -73.0),
+      bottomLeft: LatLng(39.0, -74.0),
+    );
+
+    test('toList produces 4 coordinate pairs', () {
+      final list = quad.toList() as List;
+      expect(list.length, 4);
+      expect(list[0], [40.0, -74.0]);
+      expect(list[1], [40.0, -73.0]);
+      expect(list[2], [39.0, -73.0]);
+      expect(list[3], [39.0, -74.0]);
+    });
+
+    test('fromList roundtrip', () {
+      final restored = LatLngQuad.fromList(quad.toList());
+      expect(restored, quad);
+    });
+
+    test('fromList with null returns null', () {
+      expect(LatLngQuad.fromList(null), isNull);
+    });
+
+    test('equality', () {
+      const same = LatLngQuad(
+        topLeft: LatLng(40.0, -74.0),
+        topRight: LatLng(40.0, -73.0),
+        bottomRight: LatLng(39.0, -73.0),
+        bottomLeft: LatLng(39.0, -74.0),
+      );
+      expect(quad, equals(same));
+      expect(quad.hashCode, same.hashCode);
+    });
+
+    test('inequality when one corner differs', () {
+      const different = LatLngQuad(
+        topLeft: LatLng(41.0, -74.0),
+        topRight: LatLng(40.0, -73.0),
+        bottomRight: LatLng(39.0, -73.0),
+        bottomLeft: LatLng(39.0, -74.0),
+      );
+      expect(quad, isNot(equals(different)));
+    });
+
+    test('toString', () {
+      expect(quad.toString(), contains('LatLngQuad'));
+    });
+  });
+
+  group('UserLocation', () {
+    test('basic construction', () {
+      final timestamp = DateTime(2024);
+      final location = UserLocation(
+        position: const LatLng(45.0, 90.0),
+        altitude: 100.0,
+        bearing: 180.0,
+        speed: 5.0,
+        horizontalAccuracy: 10.0,
+        verticalAccuracy: 15.0,
+        timestamp: timestamp,
+        heading: null,
+      );
+      expect(location.position, const LatLng(45.0, 90.0));
+      expect(location.altitude, 100.0);
+      expect(location.bearing, 180.0);
+      expect(location.speed, 5.0);
+      expect(location.horizontalAccuracy, 10.0);
+      expect(location.verticalAccuracy, 15.0);
+      expect(location.timestamp, timestamp);
+      expect(location.heading, isNull);
+    });
+
+    test('with nullable fields as null', () {
+      final location = UserLocation(
+        position: const LatLng(0.0, 0.0),
+        altitude: null,
+        bearing: null,
+        speed: null,
+        horizontalAccuracy: null,
+        verticalAccuracy: null,
+        timestamp: DateTime(2024),
+        heading: null,
+      );
+      expect(location.altitude, isNull);
+      expect(location.bearing, isNull);
+      expect(location.speed, isNull);
+    });
+  });
+
+  group('UserHeading', () {
+    test('basic construction', () {
+      final timestamp = DateTime(2024);
+      final heading = UserHeading(
+        magneticHeading: 90.0,
+        trueHeading: 92.0,
+        headingAccuracy: 5.0,
+        x: 1.0,
+        y: 2.0,
+        z: 3.0,
+        timestamp: timestamp,
+      );
+      expect(heading.magneticHeading, 90.0);
+      expect(heading.trueHeading, 92.0);
+      expect(heading.headingAccuracy, 5.0);
+      expect(heading.x, 1.0);
+      expect(heading.y, 2.0);
+      expect(heading.z, 3.0);
+      expect(heading.timestamp, timestamp);
+    });
+  });
+}

--- a/maplibre_gl_platform_interface/test/location_test.dart
+++ b/maplibre_gl_platform_interface/test/location_test.dart
@@ -100,7 +100,8 @@ void main() {
 
     test('toString', () {
       const latLng = LatLng(45.0, 90.0);
-      expect(latLng.toString(), 'LatLng(45.0, 90.0)');
+      // On web (JS), integer doubles print without ".0" suffix
+      expect(latLng.toString(), matches(RegExp(r'LatLng\(45\.?0?, 90\.?0?\)')));
     });
   });
 
@@ -205,9 +206,12 @@ void main() {
         southwest: const LatLng(10.0, 20.0),
         northeast: const LatLng(30.0, 40.0),
       );
+      // On web (JS), integer doubles print without ".0" suffix
       expect(
         bounds.toString(),
-        'LatLngBounds(LatLng(10.0, 20.0), LatLng(30.0, 40.0))',
+        matches(RegExp(
+          r'LatLngBounds\(LatLng\(10\.?0?, 20\.?0?\), LatLng\(30\.?0?, 40\.?0?\)\)',
+        )),
       );
     });
   });

--- a/maplibre_gl_platform_interface/test/location_test.dart
+++ b/maplibre_gl_platform_interface/test/location_test.dart
@@ -209,9 +209,11 @@ void main() {
       // On web (JS), integer doubles print without ".0" suffix
       expect(
         bounds.toString(),
-        matches(RegExp(
-          r'LatLngBounds\(LatLng\(10\.?0?, 20\.?0?\), LatLng\(30\.?0?, 40\.?0?\)\)',
-        )),
+        matches(
+          RegExp(
+            r'LatLngBounds\(LatLng\(10\.?0?, 20\.?0?\), LatLng\(30\.?0?, 40\.?0?\)\)',
+          ),
+        ),
       );
     });
   });

--- a/maplibre_gl_platform_interface/test/method_channel_callbacks_test.dart
+++ b/maplibre_gl_platform_interface/test/method_channel_callbacks_test.dart
@@ -33,7 +33,7 @@ void main() {
           .handlePlatformMessage(
             'plugins.flutter.io/maplibre_gl_0',
             data,
-            (ByteData? reply) {},
+            (_) {},
           );
     }
 
@@ -83,26 +83,28 @@ void main() {
       expect(called, isTrue);
     });
 
-    test('map#onMapClick fires onMapClickPlatform with Point and LatLng',
-        () async {
-      Map<String, dynamic>? received;
-      platform.onMapClickPlatform.add((data) => received = data);
+    test(
+      'map#onMapClick fires onMapClickPlatform with Point and LatLng',
+      () async {
+        Map<String, dynamic>? received;
+        platform.onMapClickPlatform.add((data) => received = data);
 
-      await simulateNativeCallback('map#onMapClick', {
-        'x': 100.0,
-        'y': 200.0,
-        'lng': 20.0,
-        'lat': 10.0,
-      });
+        await simulateNativeCallback('map#onMapClick', {
+          'x': 100.0,
+          'y': 200.0,
+          'lng': 20.0,
+          'lat': 10.0,
+        });
 
-      expect(received, isNotNull);
-      final point = received!['point'] as Point<double>;
-      expect(point.x, 100.0);
-      expect(point.y, 200.0);
-      final latLng = received!['latLng'] as LatLng;
-      expect(latLng.latitude, 10.0);
-      expect(latLng.longitude, 20.0);
-    });
+        expect(received, isNotNull);
+        final point = received!['point'] as Point<double>;
+        expect(point.x, 100.0);
+        expect(point.y, 200.0);
+        final latLng = received!['latLng'] as LatLng;
+        expect(latLng.latitude, 10.0);
+        expect(latLng.longitude, 20.0);
+      },
+    );
 
     test('map#onMapLongClick fires onMapLongClickPlatform', () async {
       Map<String, dynamic>? received;
@@ -187,8 +189,7 @@ void main() {
       expect(received, MyLocationTrackingMode.tracking);
     });
 
-    test('map#onUserLocationUpdated fires with correct UserLocation',
-        () async {
+    test('map#onUserLocationUpdated fires with correct UserLocation', () async {
       UserLocation? received;
       platform.onUserLocationUpdatedPlatform.add((loc) => received = loc);
 

--- a/maplibre_gl_platform_interface/test/method_channel_callbacks_test.dart
+++ b/maplibre_gl_platform_interface/test/method_channel_callbacks_test.dart
@@ -1,0 +1,261 @@
+import 'dart:math';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_gl_platform_interface/maplibre_gl_platform_interface.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('MethodChannel Callbacks', () {
+    late MapLibreMethodChannel platform;
+
+    setUp(() async {
+      platform = MapLibreMethodChannel();
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('plugins.flutter.io/maplibre_gl_0'),
+            (methodCall) async => null,
+          );
+
+      await platform.initPlatform(0);
+    });
+
+    Future<void> simulateNativeCallback(
+      String method,
+      Map<String, dynamic> arguments,
+    ) async {
+      final data = const StandardMethodCodec().encodeMethodCall(
+        MethodCall(method, arguments),
+      );
+      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage(
+            'plugins.flutter.io/maplibre_gl_0',
+            data,
+            (ByteData? reply) {},
+          );
+    }
+
+    test('camera#onMove fires onCameraMovePlatform', () async {
+      CameraPosition? received;
+      platform.onCameraMovePlatform.add((pos) => received = pos);
+
+      await simulateNativeCallback('camera#onMove', {
+        'position': {
+          'bearing': 45.0,
+          'target': <double>[10.0, 20.0],
+          'tilt': 30.0,
+          'zoom': 15.0,
+        },
+      });
+
+      expect(received, isNotNull);
+      expect(received!.bearing, 45.0);
+      expect(received!.target, const LatLng(10.0, 20.0));
+      expect(received!.tilt, 30.0);
+      expect(received!.zoom, 15.0);
+    });
+
+    test('camera#onIdle fires onCameraIdlePlatform', () async {
+      CameraPosition? received;
+      platform.onCameraIdlePlatform.add((pos) => received = pos);
+
+      await simulateNativeCallback('camera#onIdle', {
+        'position': {
+          'bearing': 0.0,
+          'target': <double>[0.0, 0.0],
+          'tilt': 0.0,
+          'zoom': 5.0,
+        },
+      });
+
+      expect(received, isNotNull);
+      expect(received!.zoom, 5.0);
+    });
+
+    test('camera#onMoveStarted fires onCameraMoveStartedPlatform', () async {
+      var called = false;
+      platform.onCameraMoveStartedPlatform.add((_) => called = true);
+
+      await simulateNativeCallback('camera#onMoveStarted', {});
+
+      expect(called, isTrue);
+    });
+
+    test('map#onMapClick fires onMapClickPlatform with Point and LatLng',
+        () async {
+      Map<String, dynamic>? received;
+      platform.onMapClickPlatform.add((data) => received = data);
+
+      await simulateNativeCallback('map#onMapClick', {
+        'x': 100.0,
+        'y': 200.0,
+        'lng': 20.0,
+        'lat': 10.0,
+      });
+
+      expect(received, isNotNull);
+      final point = received!['point'] as Point<double>;
+      expect(point.x, 100.0);
+      expect(point.y, 200.0);
+      final latLng = received!['latLng'] as LatLng;
+      expect(latLng.latitude, 10.0);
+      expect(latLng.longitude, 20.0);
+    });
+
+    test('map#onMapLongClick fires onMapLongClickPlatform', () async {
+      Map<String, dynamic>? received;
+      platform.onMapLongClickPlatform.add((data) => received = data);
+
+      await simulateNativeCallback('map#onMapLongClick', {
+        'x': 150.0,
+        'y': 250.0,
+        'lng': 30.0,
+        'lat': 20.0,
+      });
+
+      expect(received, isNotNull);
+      final latLng = received!['latLng'] as LatLng;
+      expect(latLng.latitude, 20.0);
+      expect(latLng.longitude, 30.0);
+    });
+
+    test('feature#onTap fires onFeatureTappedPlatform', () async {
+      Map<String, dynamic>? received;
+      platform.onFeatureTappedPlatform.add((data) => received = data);
+
+      await simulateNativeCallback('feature#onTap', {
+        'id': 'feature-1',
+        'x': 100.0,
+        'y': 200.0,
+        'lng': 20.0,
+        'lat': 10.0,
+        'layerId': 'my-layer',
+      });
+
+      expect(received, isNotNull);
+      expect(received!['id'], 'feature-1');
+      expect(received!['layerId'], 'my-layer');
+      expect(received!['point'], isA<Point<double>>());
+      expect(received!['latLng'], isA<LatLng>());
+    });
+
+    test('feature#onDrag fires onFeatureDraggedPlatform', () async {
+      Map<String, dynamic>? received;
+      platform.onFeatureDraggedPlatform.add((data) => received = data);
+
+      await simulateNativeCallback('feature#onDrag', {
+        'id': 'feature-1',
+        'x': 100.0,
+        'y': 200.0,
+        'originLat': 10.0,
+        'originLng': 20.0,
+        'currentLat': 11.0,
+        'currentLng': 21.0,
+        'deltaLat': 1.0,
+        'deltaLng': 1.0,
+        'eventType': 'start',
+      });
+
+      expect(received, isNotNull);
+      expect(received!['id'], 'feature-1');
+      expect(received!['eventType'], 'start');
+      final origin = received!['origin'] as LatLng;
+      expect(origin.latitude, 10.0);
+      final current = received!['current'] as LatLng;
+      expect(current.latitude, 11.0);
+    });
+
+    test('map#onStyleLoaded fires onMapStyleLoadedPlatform', () async {
+      var called = false;
+      platform.onMapStyleLoadedPlatform.add((_) => called = true);
+
+      await simulateNativeCallback('map#onStyleLoaded', {});
+
+      expect(called, isTrue);
+    });
+
+    test('map#onCameraTrackingChanged fires with correct mode', () async {
+      MyLocationTrackingMode? received;
+      platform.onCameraTrackingChangedPlatform.add((mode) => received = mode);
+
+      await simulateNativeCallback('map#onCameraTrackingChanged', {
+        'mode': MyLocationTrackingMode.tracking.index,
+      });
+
+      expect(received, MyLocationTrackingMode.tracking);
+    });
+
+    test('map#onUserLocationUpdated fires with correct UserLocation',
+        () async {
+      UserLocation? received;
+      platform.onUserLocationUpdatedPlatform.add((loc) => received = loc);
+
+      final timestamp = DateTime.now().millisecondsSinceEpoch;
+      await simulateNativeCallback('map#onUserLocationUpdated', {
+        'userLocation': {
+          'position': <double>[45.0, 90.0],
+          'altitude': 100.0,
+          'bearing': 180.0,
+          'speed': 5.0,
+          'horizontalAccuracy': 10.0,
+          'verticalAccuracy': 15.0,
+          'timestamp': timestamp,
+        },
+        'heading': {
+          'magneticHeading': 90.0,
+          'trueHeading': 92.0,
+          'headingAccuracy': 5.0,
+          'x': 1.0,
+          'y': 2.0,
+          'z': 3.0,
+          'timestamp': timestamp,
+        },
+      });
+
+      expect(received, isNotNull);
+      expect(received!.position, const LatLng(45.0, 90.0));
+      expect(received!.altitude, 100.0);
+      expect(received!.bearing, 180.0);
+      expect(received!.speed, 5.0);
+      expect(received!.heading, isNotNull);
+      expect(received!.heading!.magneticHeading, 90.0);
+      expect(received!.heading!.x, 1.0);
+      expect(received!.heading!.y, 2.0);
+      expect(received!.heading!.z, 3.0);
+    });
+
+    test('map#onUserLocationUpdated with null heading', () async {
+      UserLocation? received;
+      platform.onUserLocationUpdatedPlatform.add((loc) => received = loc);
+
+      await simulateNativeCallback('map#onUserLocationUpdated', {
+        'userLocation': {
+          'position': <double>[45.0, 90.0],
+          'altitude': 100.0,
+          'bearing': 180.0,
+          'speed': 5.0,
+          'horizontalAccuracy': 10.0,
+          'verticalAccuracy': 15.0,
+          'timestamp': DateTime.now().millisecondsSinceEpoch,
+        },
+        'heading': null,
+      });
+
+      expect(received, isNotNull);
+      expect(received!.heading, isNull);
+    });
+
+    test('infoWindow#onTap fires onInfoWindowTappedPlatform', () async {
+      String? received;
+      platform.onInfoWindowTappedPlatform.add((id) => received = id);
+
+      await simulateNativeCallback('infoWindow#onTap', {
+        'symbol': 'sym-1',
+      });
+
+      expect(received, 'sym-1');
+    });
+  });
+}

--- a/maplibre_gl_platform_interface/test/method_channel_camera_test.dart
+++ b/maplibre_gl_platform_interface/test/method_channel_camera_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_gl_platform_interface/maplibre_gl_platform_interface.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('MethodChannel Camera', () {
+    late MapLibreMethodChannel platform;
+    late List<MethodCall> methodCalls;
+
+    setUp(() async {
+      platform = MapLibreMethodChannel();
+      methodCalls = [];
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('plugins.flutter.io/maplibre_gl_0'),
+            (methodCall) async {
+              methodCalls.add(methodCall);
+
+              switch (methodCall.method) {
+                case 'map#queryCameraPosition':
+                  return <String, dynamic>{
+                    'bearing': 45.0,
+                    'target': <double>[10.0, 20.0],
+                    'tilt': 30.0,
+                    'zoom': 15.0,
+                  };
+                case 'map#update':
+                  return <String, dynamic>{
+                    'bearing': 0.0,
+                    'target': <double>[0.0, 0.0],
+                    'tilt': 0.0,
+                    'zoom': 10.0,
+                  };
+                case 'camera#animate':
+                case 'camera#move':
+                  return true;
+                case 'camera#ease':
+                  return true;
+                default:
+                  return null;
+              }
+            },
+          );
+
+      await platform.initPlatform(0);
+      methodCalls.clear();
+    });
+
+    test('animateCamera sends correct method and arguments', () async {
+      final update = CameraUpdate.newLatLng(const LatLng(10.0, 20.0));
+      await platform.animateCamera(update);
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'camera#animate');
+      final args = methodCalls[0].arguments as Map;
+      expect(args['cameraUpdate'], update.toJson());
+      expect(args['duration'], isNull);
+    });
+
+    test('animateCamera with duration', () async {
+      final update = CameraUpdate.zoomIn();
+      await platform.animateCamera(
+        update,
+        duration: const Duration(milliseconds: 500),
+      );
+
+      final args = methodCalls[0].arguments as Map;
+      expect(args['duration'], 500);
+    });
+
+    test('moveCamera sends correct method and arguments', () async {
+      final update = CameraUpdate.newLatLng(const LatLng(10.0, 20.0));
+      await platform.moveCamera(update);
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'camera#move');
+      final args = methodCalls[0].arguments as Map;
+      expect(args['cameraUpdate'], update.toJson());
+    });
+
+    test('easeCamera sends correct method and arguments', () async {
+      final update = CameraUpdate.zoomTo(12.0);
+      await platform.easeCamera(
+        update,
+        duration: const Duration(seconds: 1),
+      );
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'camera#ease');
+      final args = methodCalls[0].arguments as Map;
+      expect(args['cameraUpdate'], update.toJson());
+      expect(args['duration'], 1000);
+    });
+
+    test('queryCameraPosition returns deserialized CameraPosition', () async {
+      final result = await platform.queryCameraPosition();
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'map#queryCameraPosition');
+      expect(result, isNotNull);
+      expect(result!.bearing, 45.0);
+      expect(result.target, const LatLng(10.0, 20.0));
+      expect(result.tilt, 30.0);
+      expect(result.zoom, 15.0);
+    });
+
+    test('updateMapOptions passes options and returns CameraPosition',
+        () async {
+      final result = await platform.updateMapOptions({'zoom': 10.0});
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'map#update');
+      final args = methodCalls[0].arguments as Map;
+      expect(args['options'], {'zoom': 10.0});
+      expect(result, isNotNull);
+      expect(result!.zoom, 10.0);
+    });
+  });
+}

--- a/maplibre_gl_platform_interface/test/method_channel_camera_test.dart
+++ b/maplibre_gl_platform_interface/test/method_channel_camera_test.dart
@@ -107,16 +107,18 @@ void main() {
       expect(result.zoom, 15.0);
     });
 
-    test('updateMapOptions passes options and returns CameraPosition',
-        () async {
-      final result = await platform.updateMapOptions({'zoom': 10.0});
+    test(
+      'updateMapOptions passes options and returns CameraPosition',
+      () async {
+        final result = await platform.updateMapOptions({'zoom': 10.0});
 
-      expect(methodCalls.length, 1);
-      expect(methodCalls[0].method, 'map#update');
-      final args = methodCalls[0].arguments as Map;
-      expect(args['options'], {'zoom': 10.0});
-      expect(result, isNotNull);
-      expect(result!.zoom, 10.0);
-    });
+        expect(methodCalls.length, 1);
+        expect(methodCalls[0].method, 'map#update');
+        final args = methodCalls[0].arguments as Map;
+        expect(args['options'], {'zoom': 10.0});
+        expect(result, isNotNull);
+        expect(result!.zoom, 10.0);
+      },
+    );
   });
 }

--- a/maplibre_gl_platform_interface/test/method_channel_layer_test.dart
+++ b/maplibre_gl_platform_interface/test/method_channel_layer_test.dart
@@ -1,0 +1,199 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_gl_platform_interface/maplibre_gl_platform_interface.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('MethodChannel Layer', () {
+    late MapLibreMethodChannel platform;
+    late List<MethodCall> methodCalls;
+
+    setUp(() async {
+      platform = MapLibreMethodChannel();
+      methodCalls = [];
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('plugins.flutter.io/maplibre_gl_0'),
+            (methodCall) async {
+              methodCalls.add(methodCall);
+
+              switch (methodCall.method) {
+                case 'style#getLayerIds':
+                  return <dynamic, dynamic>{
+                    'layers': ['layer-1', 'layer-2', 'layer-3'],
+                  };
+                case 'style#getSourceIds':
+                  return <dynamic, dynamic>{
+                    'sources': ['source-1', 'source-2'],
+                  };
+                case 'layer#getVisibility':
+                  return true;
+                default:
+                  return null;
+              }
+            },
+          );
+
+      await platform.initPlatform(0);
+      methodCalls.clear();
+    });
+
+    test('addFillLayer sends correct method', () async {
+      await platform.addFillLayer(
+        'source-id',
+        'fill-layer',
+        {'fill-color': '#FF0000'},
+        enableInteraction: true,
+      );
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'fillLayer#add');
+      final args = methodCalls[0].arguments as Map;
+      expect(args['sourceId'], 'source-id');
+      expect(args['layerId'], 'fill-layer');
+      expect(args['enableInteraction'], true);
+      expect((args['properties'] as Map)['fill-color'], '#FF0000');
+    });
+
+    test('addFillExtrusionLayer sends correct method', () async {
+      await platform.addFillExtrusionLayer(
+        'source-id',
+        'extrusion-layer',
+        {'fill-extrusion-height': 100},
+        enableInteraction: false,
+      );
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'fillExtrusionLayer#add');
+      final args = methodCalls[0].arguments as Map;
+      expect(args['layerId'], 'extrusion-layer');
+    });
+
+    test('addRasterLayer sends correct method', () async {
+      await platform.addRasterLayer(
+        'raster-source',
+        'raster-layer',
+        {'raster-opacity': 0.8},
+      );
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'rasterLayer#add');
+      final args = methodCalls[0].arguments as Map;
+      expect(args['sourceId'], 'raster-source');
+      expect(args['layerId'], 'raster-layer');
+    });
+
+    test('addHillshadeLayer sends correct method', () async {
+      await platform.addHillshadeLayer(
+        'dem-source',
+        'hillshade-layer',
+        {'hillshade-exaggeration': 0.5},
+      );
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'hillshadeLayer#add');
+    });
+
+    test('addHeatmapLayer sends correct method', () async {
+      await platform.addHeatmapLayer(
+        'heat-source',
+        'heatmap-layer',
+        {'heatmap-radius': 30},
+      );
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'heatmapLayer#add');
+    });
+
+    test('addLayer sends correct method', () async {
+      await platform.addLayer('image-layer', 'image-source', 5, 15);
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'style#addLayer');
+      final args = methodCalls[0].arguments as Map;
+      expect(args['imageLayerId'], 'image-layer');
+      expect(args['imageSourceId'], 'image-source');
+      expect(args['minzoom'], 5.0);
+      expect(args['maxzoom'], 15.0);
+    });
+
+    test('addLayerBelow sends correct method', () async {
+      await platform.addLayerBelow(
+        'image-layer',
+        'image-source',
+        'below-this',
+        null,
+        null,
+      );
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'style#addLayerBelow');
+      final args = methodCalls[0].arguments as Map;
+      expect(args['belowLayerId'], 'below-this');
+    });
+
+    test('removeLayer sends correct method', () async {
+      await platform.removeLayer('layer-to-remove');
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'style#removeLayer');
+      final args = methodCalls[0].arguments as Map;
+      expect(args['layerId'], 'layer-to-remove');
+    });
+
+    test('setLayerVisibility sends correct method', () async {
+      await platform.setLayerVisibility('my-layer', false);
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'layer#setVisibility');
+      final args = methodCalls[0].arguments as Map;
+      expect(args['layerId'], 'my-layer');
+      expect(args['visible'], false);
+    });
+
+    test('getLayerVisibility returns result', () async {
+      final result = await platform.getLayerVisibility('my-layer');
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'layer#getVisibility');
+      expect(result, true);
+    });
+
+    test('getLayerIds returns list of string ids', () async {
+      final result = await platform.getLayerIds();
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'style#getLayerIds');
+      expect(result, ['layer-1', 'layer-2', 'layer-3']);
+    });
+
+    test('getSourceIds returns list of string ids', () async {
+      final result = await platform.getSourceIds();
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'style#getSourceIds');
+      expect(result, ['source-1', 'source-2']);
+    });
+
+    test('addLayer with belowLayerId and zoom bounds', () async {
+      await platform.addFillLayer(
+        'source-id',
+        'fill-layer',
+        {'fill-color': '#FF0000'},
+        belowLayerId: 'existing-layer',
+        sourceLayer: 'my-source-layer',
+        minzoom: 5,
+        maxzoom: 15,
+        enableInteraction: true,
+      );
+
+      final args = methodCalls[0].arguments as Map;
+      expect(args['belowLayerId'], 'existing-layer');
+      expect(args['sourceLayer'], 'my-source-layer');
+      expect(args['minzoom'], 5.0);
+      expect(args['maxzoom'], 15.0);
+    });
+  });
+}

--- a/maplibre_gl_platform_interface/test/method_channel_source_test.dart
+++ b/maplibre_gl_platform_interface/test/method_channel_source_test.dart
@@ -57,8 +57,7 @@ void main() {
       expect(args['geojson'], jsonEncode(geojson));
     });
 
-    test('addSource sends correct method with serialized properties',
-        () async {
+    test('addSource sends correct method with serialized properties', () async {
       const props = VectorSourceProperties(
         url: 'https://example.com/tiles.json',
       );
@@ -82,10 +81,11 @@ void main() {
       expect(args['sourceId'], 'test-source');
     });
 
-    test('editGeoJsonSource sends correct method and returns result',
-        () async {
-      final result =
-          await platform.editGeoJsonSource('src-1', '{"type":"Feature"}');
+    test('editGeoJsonSource sends correct method and returns result', () async {
+      final result = await platform.editGeoJsonSource(
+        'src-1',
+        '{"type":"Feature"}',
+      );
 
       expect(methodCalls.length, 1);
       expect(methodCalls[0].method, 'map#editGeoJsonSource');

--- a/maplibre_gl_platform_interface/test/method_channel_source_test.dart
+++ b/maplibre_gl_platform_interface/test/method_channel_source_test.dart
@@ -1,0 +1,123 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_gl_platform_interface/maplibre_gl_platform_interface.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('MethodChannel Source', () {
+    late MapLibreMethodChannel platform;
+    late List<MethodCall> methodCalls;
+
+    setUp(() async {
+      platform = MapLibreMethodChannel();
+      methodCalls = [];
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('plugins.flutter.io/maplibre_gl_0'),
+            (methodCall) async {
+              methodCalls.add(methodCall);
+
+              switch (methodCall.method) {
+                case 'map#editGeoJsonSource':
+                case 'map#editGeoJsonUrl':
+                  return <Object?, Object?>{'result': true};
+                default:
+                  return null;
+              }
+            },
+          );
+
+      await platform.initPlatform(0);
+      methodCalls.clear();
+    });
+
+    test('addGeoJsonSource sends correct method and arguments', () async {
+      final geojson = {'type': 'FeatureCollection', 'features': <dynamic>[]};
+      await platform.addGeoJsonSource('test-source', geojson);
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'source#addGeoJson');
+      final args = methodCalls[0].arguments as Map;
+      expect(args['sourceId'], 'test-source');
+      expect(args['geojson'], jsonEncode(geojson));
+    });
+
+    test('setGeoJsonSource sends correct method and arguments', () async {
+      final geojson = {'type': 'FeatureCollection', 'features': <dynamic>[]};
+      await platform.setGeoJsonSource('test-source', geojson);
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'source#setGeoJson');
+      final args = methodCalls[0].arguments as Map;
+      expect(args['sourceId'], 'test-source');
+      expect(args['geojson'], jsonEncode(geojson));
+    });
+
+    test('addSource sends correct method with serialized properties',
+        () async {
+      const props = VectorSourceProperties(
+        url: 'https://example.com/tiles.json',
+      );
+      await platform.addSource('vec-source', props);
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'style#addSource');
+      final args = methodCalls[0].arguments as Map;
+      expect(args['sourceId'], 'vec-source');
+      final properties = args['properties'] as Map;
+      expect(properties['type'], 'vector');
+      expect(properties['url'], 'https://example.com/tiles.json');
+    });
+
+    test('removeSource sends correct method', () async {
+      await platform.removeSource('test-source');
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'style#removeSource');
+      final args = methodCalls[0].arguments as Map;
+      expect(args['sourceId'], 'test-source');
+    });
+
+    test('editGeoJsonSource sends correct method and returns result',
+        () async {
+      final result =
+          await platform.editGeoJsonSource('src-1', '{"type":"Feature"}');
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'map#editGeoJsonSource');
+      final args = methodCalls[0].arguments as Map;
+      expect(args['id'], 'src-1');
+      expect(args['data'], '{"type":"Feature"}');
+      expect(result, true);
+    });
+
+    test('editGeoJsonUrl sends correct method and returns result', () async {
+      final result = await platform.editGeoJsonUrl(
+        'src-1',
+        'https://example.com/data.geojson',
+      );
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'map#editGeoJsonUrl');
+      final args = methodCalls[0].arguments as Map;
+      expect(args['id'], 'src-1');
+      expect(args['url'], 'https://example.com/data.geojson');
+      expect(result, true);
+    });
+
+    test('setFeatureForGeoJsonSource sends correct method', () async {
+      final feature = {'type': 'Feature', 'properties': <String, dynamic>{}};
+      await platform.setFeatureForGeoJsonSource('src-1', feature);
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'source#setFeature');
+      final args = methodCalls[0].arguments as Map;
+      expect(args['sourceId'], 'src-1');
+      expect(args['geojsonFeature'], jsonEncode(feature));
+    });
+  });
+}

--- a/maplibre_gl_platform_interface/test/source_properties_test.dart
+++ b/maplibre_gl_platform_interface/test/source_properties_test.dart
@@ -1,0 +1,276 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_gl_platform_interface/maplibre_gl_platform_interface.dart';
+
+void main() {
+  group('VectorSourceProperties', () {
+    test('toJson includes type "vector"', () {
+      const props = VectorSourceProperties();
+      final json = props.toJson();
+      expect(json['type'], 'vector');
+    });
+
+    test('default values are included in toJson', () {
+      const props = VectorSourceProperties();
+      final json = props.toJson();
+      expect(json['bounds'], [-180, -85.051129, 180, 85.051129]);
+      expect(json['scheme'], 'xyz');
+      expect(json['minzoom'], 0);
+      expect(json['maxzoom'], 22);
+    });
+
+    test('toJson omits null fields', () {
+      const props = VectorSourceProperties();
+      final json = props.toJson();
+      expect(json.containsKey('url'), isFalse);
+      expect(json.containsKey('tiles'), isFalse);
+      expect(json.containsKey('attribution'), isFalse);
+      expect(json.containsKey('promoteId'), isFalse);
+    });
+
+    test('toJson includes non-null fields', () {
+      const props = VectorSourceProperties(
+        url: 'https://example.com/tiles.json',
+        tiles: ['https://example.com/{z}/{x}/{y}.pbf'],
+        attribution: '(c) Test',
+      );
+      final json = props.toJson();
+      expect(json['url'], 'https://example.com/tiles.json');
+      expect(json['tiles'], ['https://example.com/{z}/{x}/{y}.pbf']);
+      expect(json['attribution'], '(c) Test');
+    });
+
+    test('fromJson roundtrip', () {
+      const original = VectorSourceProperties(
+        url: 'https://example.com/tiles.json',
+        minzoom: 2,
+        maxzoom: 14,
+      );
+      final restored = VectorSourceProperties.fromJson(original.toJson());
+      expect(restored.url, original.url);
+      expect(restored.minzoom, original.minzoom);
+      expect(restored.maxzoom, original.maxzoom);
+    });
+
+    test('copyWith replaces specified fields', () {
+      const original = VectorSourceProperties(
+        url: 'https://old.com',
+      );
+      final updated = original.copyWith('https://new.com', null, null,
+          null, 5, null, null, null);
+      expect(updated.url, 'https://new.com');
+      expect(updated.minzoom, 5);
+      expect(updated.maxzoom, 22); // preserved default
+    });
+  });
+
+  group('RasterSourceProperties', () {
+    test('toJson includes type "raster"', () {
+      const props = RasterSourceProperties();
+      final json = props.toJson();
+      expect(json['type'], 'raster');
+    });
+
+    test('default values', () {
+      const props = RasterSourceProperties();
+      final json = props.toJson();
+      expect(json['minzoom'], 0);
+      expect(json['maxzoom'], 22);
+      expect(json['tileSize'], 512);
+      expect(json['scheme'], 'xyz');
+    });
+
+    test('fromJson roundtrip', () {
+      const original = RasterSourceProperties(
+        url: 'https://example.com/raster',
+        tileSize: 256,
+      );
+      final restored = RasterSourceProperties.fromJson(original.toJson());
+      expect(restored.url, original.url);
+      expect(restored.tileSize, original.tileSize);
+    });
+
+    test('copyWith replaces specified fields', () {
+      const original = RasterSourceProperties();
+      final updated = original.copyWith(
+          null, null, null, null, null, 256, null, null);
+      expect(updated.tileSize, 256);
+      expect(updated.scheme, 'xyz'); // preserved
+    });
+  });
+
+  group('RasterDemSourceProperties', () {
+    test('toJson includes type "raster-dem"', () {
+      const props = RasterDemSourceProperties();
+      final json = props.toJson();
+      expect(json['type'], 'raster-dem');
+    });
+
+    test('default encoding is "mapbox"', () {
+      const props = RasterDemSourceProperties();
+      final json = props.toJson();
+      expect(json['encoding'], 'mapbox');
+    });
+
+    test('fromJson roundtrip', () {
+      const original = RasterDemSourceProperties(
+        encoding: 'terrarium',
+        tileSize: 256,
+      );
+      final restored = RasterDemSourceProperties.fromJson(original.toJson());
+      expect(restored.encoding, 'terrarium');
+      expect(restored.tileSize, 256);
+    });
+
+    test('copyWith replaces specified fields', () {
+      const original = RasterDemSourceProperties();
+      final updated = original.copyWith(
+          null, null, null, null, null, null, null, 'terrarium');
+      expect(updated.encoding, 'terrarium');
+    });
+  });
+
+  group('GeojsonSourceProperties', () {
+    test('toJson includes type "geojson"', () {
+      const props = GeojsonSourceProperties();
+      final json = props.toJson();
+      expect(json['type'], 'geojson');
+    });
+
+    test('default values', () {
+      const props = GeojsonSourceProperties();
+      final json = props.toJson();
+      expect(json['maxzoom'], 18);
+      expect(json['buffer'], 128);
+      expect(json['tolerance'], 0.375);
+      expect(json['cluster'], false);
+      expect(json['clusterRadius'], 50);
+      expect(json['lineMetrics'], false);
+      expect(json['generateId'], false);
+    });
+
+    test('toJson omits null fields', () {
+      const props = GeojsonSourceProperties();
+      final json = props.toJson();
+      expect(json.containsKey('data'), isFalse);
+      expect(json.containsKey('attribution'), isFalse);
+      expect(json.containsKey('clusterMaxZoom'), isFalse);
+    });
+
+    test('toJson with data', () {
+      const props = GeojsonSourceProperties(
+        data: 'https://example.com/data.geojson',
+        cluster: true,
+        clusterRadius: 75,
+      );
+      final json = props.toJson();
+      expect(json['data'], 'https://example.com/data.geojson');
+      expect(json['cluster'], true);
+      expect(json['clusterRadius'], 75);
+    });
+
+    test('fromJson roundtrip', () {
+      const original = GeojsonSourceProperties(
+        data: 'https://example.com/data.geojson',
+        cluster: true,
+        clusterMaxZoom: 14,
+      );
+      final restored = GeojsonSourceProperties.fromJson(original.toJson());
+      expect(restored.data, original.data);
+      expect(restored.cluster, original.cluster);
+      expect(restored.clusterMaxZoom, original.clusterMaxZoom);
+    });
+
+    test('copyWith replaces specified fields', () {
+      const original = GeojsonSourceProperties();
+      final updated = original.copyWith(
+          null, null, null, null, null, true, null, null, null, null, null,
+          null);
+      expect(updated.cluster, true);
+      expect(updated.buffer, 128); // preserved
+    });
+  });
+
+  group('VideoSourceProperties', () {
+    test('toJson includes type "video"', () {
+      const props = VideoSourceProperties();
+      final json = props.toJson();
+      expect(json['type'], 'video');
+    });
+
+    test('toJson omits null fields', () {
+      const props = VideoSourceProperties();
+      final json = props.toJson();
+      expect(json.containsKey('urls'), isFalse);
+      expect(json.containsKey('coordinates'), isFalse);
+    });
+
+    test('toJson with values', () {
+      const props = VideoSourceProperties(
+        urls: ['https://example.com/video.mp4'],
+        coordinates: [
+          [-122.51596391201019, 37.56238816766053],
+          [-122.51467645168304, 37.56410183312965],
+        ],
+      );
+      final json = props.toJson();
+      expect(json['urls'], ['https://example.com/video.mp4']);
+      expect(json['coordinates'], isA<List>());
+    });
+
+    test('fromJson roundtrip', () {
+      const original = VideoSourceProperties(
+        urls: ['https://example.com/video.mp4'],
+      );
+      final restored = VideoSourceProperties.fromJson(original.toJson());
+      expect(restored.urls, original.urls);
+    });
+
+    test('copyWith replaces specified fields', () {
+      const original = VideoSourceProperties(
+        urls: ['https://old.com/video.mp4'],
+      );
+      final updated =
+          original.copyWith(['https://new.com/video.mp4'], null);
+      expect(updated.urls, ['https://new.com/video.mp4']);
+    });
+  });
+
+  group('ImageSourceProperties', () {
+    test('toJson includes type "image"', () {
+      const props = ImageSourceProperties();
+      final json = props.toJson();
+      expect(json['type'], 'image');
+    });
+
+    test('toJson omits null fields', () {
+      const props = ImageSourceProperties();
+      final json = props.toJson();
+      expect(json.containsKey('url'), isFalse);
+      expect(json.containsKey('coordinates'), isFalse);
+    });
+
+    test('toJson with values', () {
+      const props = ImageSourceProperties(
+        url: 'https://example.com/image.png',
+      );
+      final json = props.toJson();
+      expect(json['url'], 'https://example.com/image.png');
+    });
+
+    test('fromJson roundtrip', () {
+      const original = ImageSourceProperties(
+        url: 'https://example.com/image.png',
+      );
+      final restored = ImageSourceProperties.fromJson(original.toJson());
+      expect(restored.url, original.url);
+    });
+
+    test('copyWith replaces specified fields', () {
+      const original = ImageSourceProperties(
+        url: 'https://old.com/image.png',
+      );
+      final updated = original.copyWith('https://new.com/image.png', null);
+      expect(updated.url, 'https://new.com/image.png');
+    });
+  });
+}

--- a/maplibre_gl_platform_interface/test/source_properties_test.dart
+++ b/maplibre_gl_platform_interface/test/source_properties_test.dart
@@ -55,8 +55,16 @@ void main() {
       const original = VectorSourceProperties(
         url: 'https://old.com',
       );
-      final updated = original.copyWith('https://new.com', null, null,
-          null, 5, null, null, null);
+      final updated = original.copyWith(
+        'https://new.com',
+        null,
+        null,
+        null,
+        5,
+        null,
+        null,
+        null,
+      );
       expect(updated.url, 'https://new.com');
       expect(updated.minzoom, 5);
       expect(updated.maxzoom, 22); // preserved default
@@ -92,7 +100,15 @@ void main() {
     test('copyWith replaces specified fields', () {
       const original = RasterSourceProperties();
       final updated = original.copyWith(
-          null, null, null, null, null, 256, null, null);
+        null,
+        null,
+        null,
+        null,
+        null,
+        256,
+        null,
+        null,
+      );
       expect(updated.tileSize, 256);
       expect(updated.scheme, 'xyz'); // preserved
     });
@@ -124,7 +140,15 @@ void main() {
     test('copyWith replaces specified fields', () {
       const original = RasterDemSourceProperties();
       final updated = original.copyWith(
-          null, null, null, null, null, null, null, 'terrarium');
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        'terrarium',
+      );
       expect(updated.encoding, 'terrarium');
     });
   });
@@ -183,8 +207,19 @@ void main() {
     test('copyWith replaces specified fields', () {
       const original = GeojsonSourceProperties();
       final updated = original.copyWith(
-          null, null, null, null, null, true, null, null, null, null, null,
-          null);
+        null,
+        null,
+        null,
+        null,
+        null,
+        true,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+      );
       expect(updated.cluster, true);
       expect(updated.buffer, 128); // preserved
     });
@@ -229,8 +264,7 @@ void main() {
       const original = VideoSourceProperties(
         urls: ['https://old.com/video.mp4'],
       );
-      final updated =
-          original.copyWith(['https://new.com/video.mp4'], null);
+      final updated = original.copyWith(['https://new.com/video.mp4'], null);
       expect(updated.urls, ['https://new.com/video.mp4']);
     });
   });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,13 +36,25 @@ melos:
       description: Run IO tests
       exec: flutter test
       packageFilters:
-        scope: maplibre_gl_platform_interface
+        scope:
+          - maplibre_gl_platform_interface
+          - maplibre_gl
+
+    test:io:coverage:
+      description: Run IO tests with coverage
+      exec: flutter test --coverage
+      packageFilters:
+        scope:
+          - maplibre_gl_platform_interface
+          - maplibre_gl
 
     test:web:
       description: Run Web tests
       exec: flutter test --platform chrome
       packageFilters:
-        scope: maplibre_gl_platform_interface
+        scope:
+          - maplibre_gl_platform_interface
+          - maplibre_gl
 
     analyze-all:
       description: Run static analysis on all packages


### PR DESCRIPTION
## Summary
- Add comprehensive test suite across `maplibre_gl` and `maplibre_gl_platform_interface` (from 5 tests to 303)
- Test coverage includes: data models (LatLng, Camera, Annotations, Sources), MethodChannel bridge, controller delegation, annotation managers (CRUD, GeoJSON output, tap callbacks), and layer properties
- Fix copy-paste bug in `method_channel_maplibre_gl.dart`: `z: heading['x']` → `z: heading['z']` in UserHeading deserialization
- Add `FakeMapLibrePlatform` test helper for controller/manager testing without native platform
- Enable coverage tracking in CI and add `--no-select` flag to melos commands for reliable non-interactive execution
- Expand CI test scope to include `maplibre_gl` package (previously only `maplibre_gl_platform_interface`)