### PR TITLE
feat: Make initialCameraPosition nullable to support style-defined camera options

### DIFF
--- a/maplibre_gl/lib/src/controller.dart
+++ b/maplibre_gl/lib/src/controller.dart
@@ -102,7 +102,7 @@ typedef OnMapIdleCallback = void Function();
 class MapLibreMapController extends ChangeNotifier {
   MapLibreMapController({
     required MapLibrePlatform maplibrePlatform,
-    required CameraPosition initialCameraPosition,
+    CameraPosition? initialCameraPosition,
     required Iterable<AnnotationType> annotationOrder,
     required Iterable<AnnotationType> annotationConsumeTapEvents,
     this.onStyleLoadedCallback,
@@ -203,6 +203,18 @@ class MapLibreMapController extends ChangeNotifier {
     });
 
     _maplibrePlatform.onMapStyleLoadedPlatform.add((_) async {
+      // Dispose old managers before re-creating them for the new style.
+      // This prevents stale in-flight method channel calls from racing
+      // with a new style that has cleared the native Style reference.
+      await fillManager?.dispose();
+      fillManager = null;
+      await lineManager?.dispose();
+      lineManager = null;
+      await circleManager?.dispose();
+      circleManager = null;
+      await symbolManager?.dispose();
+      symbolManager = null;
+
       final interactionEnabled = annotationConsumeTapEvents.toSet();
       for (final type in annotationOrder.toSet()) {
         final enableInteraction = interactionEnabled.contains(type);

--- a/maplibre_gl/lib/src/controller.dart
+++ b/maplibre_gl/lib/src/controller.dart
@@ -206,13 +206,21 @@ class MapLibreMapController extends ChangeNotifier {
       // Dispose old managers before re-creating them for the new style.
       // This prevents stale in-flight method channel calls from racing
       // with a new style that has cleared the native Style reference.
-      await fillManager?.dispose();
+      try {
+        await fillManager?.dispose();
+      } catch (_) {}
       fillManager = null;
-      await lineManager?.dispose();
+      try {
+        await lineManager?.dispose();
+      } catch (_) {}
       lineManager = null;
-      await circleManager?.dispose();
+      try {
+        await circleManager?.dispose();
+      } catch (_) {}
       circleManager = null;
-      await symbolManager?.dispose();
+      try {
+        await symbolManager?.dispose();
+      } catch (_) {}
       symbolManager = null;
 
       final interactionEnabled = annotationConsumeTapEvents.toSet();

--- a/maplibre_gl/lib/src/maplibre_map.dart
+++ b/maplibre_gl/lib/src/maplibre_map.dart
@@ -13,7 +13,7 @@ typedef MapCreatedCallback = void Function(MapLibreMapController controller);
 class MapLibreMap extends StatefulWidget {
   const MapLibreMap({
     super.key,
-    required this.initialCameraPosition,
+    this.initialCameraPosition,
     this.styleString = MapLibreStyles.demo,
     this.onMapCreated,
     this.onStyleLoadedCallback,
@@ -114,12 +114,13 @@ class MapLibreMap extends StatefulWidget {
 
   /// The initial position of the map's camera.
   ///
-  /// **Web note (MapLibre GL JS v5+):** If the map style contains camera
-  /// properties (`center`, `zoom`, `bearing`, `pitch`), the style values take
-  /// priority and this parameter is ignored. To override the style's camera on
-  /// web, call [MapLibreMapController.moveCamera] or
-  /// [MapLibreMapController.animateCamera] after the map is loaded.
-  final CameraPosition initialCameraPosition;
+  /// If `null`, the map style's camera properties (`center`, `zoom`,
+  /// `bearing`, `pitch`) are used. If the style also has no camera properties,
+  /// the map defaults to center `[0, 0]` at zoom `0`.
+  ///
+  /// When set, this takes priority over the style's camera properties on all
+  /// platforms.
+  final CameraPosition? initialCameraPosition;
 
   /// How long a user has to click the map **on iOS** until a long click is registered.
   /// Has no effect on web or Android. Can not be changed at runtime, only the initial value is used.
@@ -332,7 +333,8 @@ class _MapLibreMapState extends State<MapLibreMap> {
       "annotationOrder must not have duplicate types",
     );
     final creationParams = <String, dynamic>{
-      'initialCameraPosition': widget.initialCameraPosition.toMap(),
+      if (widget.initialCameraPosition != null)
+        'initialCameraPosition': widget.initialCameraPosition!.toMap(),
       'styleString': widget.styleString,
       'options': _MapLibreMapOptions.fromWidget(widget).toMap(),
       'dragEnabled': widget.dragEnabled,

--- a/maplibre_gl/test/helpers/fake_platform.dart
+++ b/maplibre_gl/test/helpers/fake_platform.dart
@@ -39,13 +39,23 @@ class FakeMapLibrePlatform extends MapLibrePlatform {
     calls.add(PlatformCall('initPlatform', [id]));
   }
 
+  /// The last creationParams passed to [buildView].
+  Map<String, dynamic>? lastCreationParams;
+
+  /// Whether [buildView] should automatically trigger [onPlatformViewCreated].
+  bool triggerPlatformViewCreated = false;
+
   @override
   Widget buildView(
     Map<String, dynamic> creationParams,
     OnPlatformViewCreatedCallback onPlatformViewCreated,
     Set<Factory<OneSequenceGestureRecognizer>>? gestureRecognizers,
   ) {
-    calls.add(PlatformCall('buildView'));
+    lastCreationParams = creationParams;
+    calls.add(PlatformCall('buildView', [creationParams]));
+    if (triggerPlatformViewCreated) {
+      onPlatformViewCreated(0);
+    }
     return const SizedBox.shrink();
   }
 

--- a/maplibre_gl/test/maplibre_map_test.dart
+++ b/maplibre_gl/test/maplibre_map_test.dart
@@ -33,8 +33,7 @@ void main() {
       expect(params, isNotNull);
       expect(params!.containsKey('initialCameraPosition'), isTrue);
 
-      final cameraMap =
-          params['initialCameraPosition'] as Map<String, dynamic>;
+      final cameraMap = params['initialCameraPosition'] as Map<String, dynamic>;
       expect(cameraMap['bearing'], 45.0);
       expect(cameraMap['zoom'], 12.0);
       expect(cameraMap['tilt'], 30.0);
@@ -53,8 +52,7 @@ void main() {
       expect(params!.containsKey('initialCameraPosition'), isFalse);
     });
 
-    testWidgets(
-        'no initialCameraPosition and style without camera settings '
+    testWidgets('no initialCameraPosition and style without camera settings '
         'falls back to platform default', (tester) async {
       // Style has no center/zoom/bearing/pitch — platform must fall back
       // to its own defaults (typically center [0,0], zoom 0).
@@ -107,8 +105,7 @@ void main() {
 
       final params = platform.lastCreationParams!;
       expect(params.containsKey('initialCameraPosition'), isTrue);
-      final cameraMap =
-          params['initialCameraPosition'] as Map<String, dynamic>;
+      final cameraMap = params['initialCameraPosition'] as Map<String, dynamic>;
       expect(cameraMap['zoom'], 0.0);
       expect(cameraMap['bearing'], 0.0);
       expect(cameraMap['tilt'], 0.0);
@@ -147,8 +144,7 @@ void main() {
       controller.dispose();
     });
 
-    test(
-        'null camera with no style camera — '
+    test('null camera with no style camera — '
         'platform reports default position on idle', () {
       // Neither initialCameraPosition nor style camera is set.
       final controller = MapLibreMapController(
@@ -171,8 +167,7 @@ void main() {
       controller.dispose();
     });
 
-    test(
-        'null camera with style camera — '
+    test('null camera with style camera — '
         'platform reports style position on idle', () {
       // initialCameraPosition is null; style has center/zoom.
       // The platform should use the style camera and report it back.

--- a/maplibre_gl/test/maplibre_map_test.dart
+++ b/maplibre_gl/test/maplibre_map_test.dart
@@ -11,6 +11,10 @@ void main() {
 
   setUp(() {
     platform = FakeMapLibrePlatform();
+    final previousFactory = MapLibrePlatform.createInstance;
+    addTearDown(() {
+      MapLibrePlatform.createInstance = previousFactory;
+    });
     MapLibrePlatform.createInstance = () => platform;
   });
 

--- a/maplibre_gl/test/maplibre_map_test.dart
+++ b/maplibre_gl/test/maplibre_map_test.dart
@@ -119,6 +119,38 @@ void main() {
     });
   });
 
+  group('onStyleLoaded manager disposal', () {
+    test('disposes old managers and re-creates them on style reload', () async {
+      final controller = MapLibreMapController(
+        maplibrePlatform: platform,
+        annotationOrder: AnnotationType.values,
+        annotationConsumeTapEvents: AnnotationType.values,
+      );
+
+      // First style load — creates managers.
+      platform.onMapStyleLoadedPlatform.call(null);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(controller.fillManager, isNotNull);
+      expect(controller.lineManager, isNotNull);
+      expect(controller.circleManager, isNotNull);
+      expect(controller.symbolManager, isNotNull);
+
+      final oldFill = controller.fillManager;
+      final oldLine = controller.lineManager;
+
+      // Second style load — disposes old managers, creates new ones.
+      platform.onMapStyleLoadedPlatform.call(null);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(controller.fillManager, isNotNull);
+      expect(controller.fillManager, isNot(same(oldFill)));
+      expect(controller.lineManager, isNot(same(oldLine)));
+
+      controller.dispose();
+    });
+  });
+
   group('Controller initialCameraPosition', () {
     test('cameraPosition is null when initialCameraPosition is null', () {
       final controller = MapLibreMapController(

--- a/maplibre_gl/test/maplibre_map_test.dart
+++ b/maplibre_gl/test/maplibre_map_test.dart
@@ -1,0 +1,208 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_gl/maplibre_gl.dart';
+
+import 'helpers/fake_platform.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FakeMapLibrePlatform platform;
+
+  setUp(() {
+    platform = FakeMapLibrePlatform();
+    MapLibrePlatform.createInstance = () => platform;
+  });
+
+  group('initialCameraPosition', () {
+    testWidgets('is included in creationParams when set', (tester) async {
+      const camera = CameraPosition(
+        target: LatLng(37.7749, -122.4194),
+        zoom: 12,
+        bearing: 45,
+        tilt: 30,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MapLibreMap(initialCameraPosition: camera),
+        ),
+      );
+
+      final params = platform.lastCreationParams;
+      expect(params, isNotNull);
+      expect(params!.containsKey('initialCameraPosition'), isTrue);
+
+      final cameraMap =
+          params['initialCameraPosition'] as Map<String, dynamic>;
+      expect(cameraMap['bearing'], 45.0);
+      expect(cameraMap['zoom'], 12.0);
+      expect(cameraMap['tilt'], 30.0);
+      final target = cameraMap['target'] as List;
+      expect(target[0], 37.7749); // lat
+      expect(target[1], -122.4194); // lng
+    });
+
+    testWidgets('is omitted from creationParams when null', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(home: MapLibreMap()),
+      );
+
+      final params = platform.lastCreationParams;
+      expect(params, isNotNull);
+      expect(params!.containsKey('initialCameraPosition'), isFalse);
+    });
+
+    testWidgets(
+        'no initialCameraPosition and style without camera settings '
+        'falls back to platform default', (tester) async {
+      // Style has no center/zoom/bearing/pitch — platform must fall back
+      // to its own defaults (typically center [0,0], zoom 0).
+      const noCameraStyle =
+          '{"version":8,"sources":{},"layers":[{"id":"bg","type":"background","paint":{"background-color":"#fff"}}]}';
+
+      platform.triggerPlatformViewCreated = true;
+      MapLibreMapController? controller;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MapLibreMap(
+            styleString: noCameraStyle,
+            onMapCreated: (c) => controller = c,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // creationParams should have no camera
+      final params = platform.lastCreationParams!;
+      expect(params.containsKey('initialCameraPosition'), isFalse);
+      expect(params['styleString'], noCameraStyle);
+
+      // Controller starts with no camera knowledge
+      expect(controller, isNotNull);
+      expect(controller!.cameraPosition, isNull);
+
+      // Platform settles on default [0,0] zoom 0 (no style camera either)
+      const platformDefault = CameraPosition(target: LatLng(0, 0));
+      platform.onCameraIdlePlatform.call(platformDefault);
+
+      expect(controller!.cameraPosition, isNotNull);
+      expect(controller!.cameraPosition!.target, const LatLng(0, 0));
+      expect(controller!.cameraPosition!.zoom, 0);
+    });
+
+    testWidgets('camera with default values is still sent to platform', (
+      tester,
+    ) async {
+      // User explicitly sets center [0,0] — this IS an intentional
+      // camera position and must be forwarded to the platform.
+      const camera = CameraPosition(target: LatLng(0, 0));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MapLibreMap(initialCameraPosition: camera),
+        ),
+      );
+
+      final params = platform.lastCreationParams!;
+      expect(params.containsKey('initialCameraPosition'), isTrue);
+      final cameraMap =
+          params['initialCameraPosition'] as Map<String, dynamic>;
+      expect(cameraMap['zoom'], 0.0);
+      expect(cameraMap['bearing'], 0.0);
+      expect(cameraMap['tilt'], 0.0);
+      final target = cameraMap['target'] as List;
+      expect(target[0], 0.0);
+      expect(target[1], 0.0);
+    });
+  });
+
+  group('Controller initialCameraPosition', () {
+    test('cameraPosition is null when initialCameraPosition is null', () {
+      final controller = MapLibreMapController(
+        maplibrePlatform: platform,
+        annotationOrder: AnnotationType.values,
+        annotationConsumeTapEvents: AnnotationType.values,
+      );
+
+      expect(controller.cameraPosition, isNull);
+      controller.dispose();
+    });
+
+    test('cameraPosition matches provided initialCameraPosition', () {
+      const camera = CameraPosition(
+        target: LatLng(10, 20),
+        zoom: 5,
+      );
+
+      final controller = MapLibreMapController(
+        maplibrePlatform: platform,
+        initialCameraPosition: camera,
+        annotationOrder: AnnotationType.values,
+        annotationConsumeTapEvents: AnnotationType.values,
+      );
+
+      expect(controller.cameraPosition, camera);
+      controller.dispose();
+    });
+
+    test(
+        'null camera with no style camera — '
+        'platform reports default position on idle', () {
+      // Neither initialCameraPosition nor style camera is set.
+      final controller = MapLibreMapController(
+        maplibrePlatform: platform,
+        annotationOrder: AnnotationType.values,
+        annotationConsumeTapEvents: AnnotationType.values,
+      );
+
+      // Before any platform event, controller has no camera knowledge.
+      expect(controller.cameraPosition, isNull);
+
+      // The platform settles on its default (center [0,0], zoom 0).
+      const platformDefault = CameraPosition(target: LatLng(0, 0));
+      platform.onCameraIdlePlatform.call(platformDefault);
+
+      expect(controller.cameraPosition, isNotNull);
+      expect(controller.cameraPosition!.target, const LatLng(0, 0));
+      expect(controller.cameraPosition!.zoom, 0);
+
+      controller.dispose();
+    });
+
+    test(
+        'null camera with style camera — '
+        'platform reports style position on idle', () {
+      // initialCameraPosition is null; style has center/zoom.
+      // The platform should use the style camera and report it back.
+      final controller = MapLibreMapController(
+        maplibrePlatform: platform,
+        annotationOrder: AnnotationType.values,
+        annotationConsumeTapEvents: AnnotationType.values,
+      );
+
+      expect(controller.cameraPosition, isNull);
+
+      // Simulate the platform applying the style's camera.
+      const styleCamera = CameraPosition(
+        target: LatLng(17.654, 32.954),
+        zoom: 0.86,
+      );
+      platform.onCameraIdlePlatform.call(styleCamera);
+
+      expect(controller.cameraPosition, isNotNull);
+      expect(
+        controller.cameraPosition!.target.latitude,
+        closeTo(17.654, 1e-6),
+      );
+      expect(
+        controller.cameraPosition!.target.longitude,
+        closeTo(32.954, 1e-6),
+      );
+      expect(controller.cameraPosition!.zoom, closeTo(0.86, 1e-6));
+
+      controller.dispose();
+    });
+  });
+}


### PR DESCRIPTION


## Summary
- Follows #761 changes.
- Make initialCameraPosition optional (CameraPosition?) on MapLibreMap widget
- When null, the map defers to the style's camera properties (center, zoom, bearing, pitch) as defined in the [MapLibre Style Spec](https://maplibre.org/maplibre-style-spec/root/#center)
- Remove incorrect v5 docstring that claimed style values override constructor camera — upstream GL JS v5 does the opposite
- All platforms (Web, Android, iOS) already handle absent initialCameraPosition gracefully

## Test plan
Added widget and controller tests covering:
- Camera set → included in creationParams
- Camera null → omitted from creationParams
- Camera with default values (e.g. LatLng(0,0)) → still forwarded
- Null camera + no-camera style → platform falls back to [0,0] zoom 0
- Null camera + style with camera → platform applies style camera