### PR TITLE
Fixed missing prototype on empty JS object created via interop

### DIFF
--- a/maplibre_gl_web/lib/src/interop/js.dart
+++ b/maplibre_gl_web/lib/src/interop/js.dart
@@ -26,6 +26,7 @@ List<String> objectKeys(Object? obj) {
 /// Extension type to add property getter/setter to JSObject.
 extension type JSObjectExt._(JSObject _) implements JSObject {
   external JSAny? operator [](String property);
+
   external void operator []=(String property, JSAny? value);
 }
 
@@ -43,9 +44,12 @@ void setJsProperty(JSObject obj, String propertyName, JSAny? value) {
 @JS('Object.create')
 external JSObject _createJsObject(JSAny? prototype);
 
+@JS('Object.prototype')
+external JSAny? _objectPrototype;
+
 /// Helper function to create an empty JavaScript object.
 JSObject createJsObject() {
-  return _createJsObject(null);
+  return _createJsObject(_objectPrototype);
 }
 
 /// Parse a JSON string using JavaScript's native JSON.parse.


### PR DESCRIPTION
Recently added `createJsObject` function creates new JS object by calling `Object.create(null)`, which creates it without prototype. This leads to issues when calling standard JS object functions (`toString()` and more...). See [this StackOverflow question](https://stackoverflow.com/questions/15518328/is-creating-js-object-with-object-createnull-the-same-as) for more details.

Changed this function so that new JS object is created using `Object.create(Object.prototype)` instead, which should be equivalent to `{}` in JS.