### PR TITLE
implement clusterProperties and fix iOS expression handling

### DIFF
--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/SourcePropertyConverter.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/SourcePropertyConverter.java
@@ -2,6 +2,9 @@ package org.maplibre.maplibregl;
 
 import android.net.Uri;
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import org.maplibre.android.style.expressions.Expression;
 import org.maplibre.geojson.FeatureCollection;
 import org.maplibre.android.geometry.LatLng;
 import org.maplibre.android.geometry.LatLngQuad;
@@ -107,6 +110,24 @@ class SourcePropertyConverter {
     if (tolerance != null) {
       options = options.withTolerance(Convert.toFloat(tolerance));
     }
+
+    final Object clusterProperties = data.get("clusterProperties");
+    if (clusterProperties instanceof Map) {
+      final Gson gson = new Gson();
+      for (Map.Entry<?, ?> entry : ((Map<?, ?>) clusterProperties).entrySet()) {
+        final String propertyName = entry.getKey().toString();
+        if (!(entry.getValue() instanceof List)) continue;
+        final List<?> value = (List<?>) entry.getValue();
+        if (value.size() < 2) continue;
+        // Format: [operator, map_expression]
+        final JsonElement operatorJson = JsonParser.parseString(gson.toJson(value.get(0)));
+        final JsonElement mapExprJson = JsonParser.parseString(gson.toJson(value.get(1)));
+        final Expression operatorExpr = Expression.Converter.convert(operatorJson);
+        final Expression mapExpr = Expression.Converter.convert(mapExprJson);
+        options = options.withClusterProperty(propertyName, operatorExpr, mapExpr);
+      }
+    }
+
     return options;
   }
 

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/SourcePropertyConverter.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/SourcePropertyConverter.java
@@ -20,6 +20,8 @@ import org.maplibre.android.style.sources.VectorSource;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -119,8 +121,20 @@ class SourcePropertyConverter {
         if (!(entry.getValue() instanceof List)) continue;
         final List<?> value = (List<?>) entry.getValue();
         if (value.size() < 2) continue;
-        // Format: [operator, map_expression]
-        final JsonElement operatorJson = JsonParser.parseString(gson.toJson(value.get(0)));
+        // Format: [operator, map_expression]. The operator may be a simple string
+        // (e.g. "+") that needs expanding to ["+", ["accumulated"], ["get", propertyName]],
+        // or a full reduce-expression array that is passed through as-is.
+        final Object opRaw = value.get(0);
+        final JsonElement operatorJson;
+        if (opRaw instanceof String) {
+          final List<Object> expanded = Arrays.asList(
+              opRaw,
+              Collections.singletonList("accumulated"),
+              Arrays.asList("get", propertyName));
+          operatorJson = JsonParser.parseString(gson.toJson(expanded));
+        } else {
+          operatorJson = JsonParser.parseString(gson.toJson(opRaw));
+        }
         final JsonElement mapExprJson = JsonParser.parseString(gson.toJson(value.get(1)));
         final Expression operatorExpr = Expression.Converter.convert(operatorJson);
         final Expression mapExpr = Expression.Converter.convert(mapExprJson);

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/LayerPropertyConverter.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/LayerPropertyConverter.swift
@@ -514,10 +514,11 @@ class LayerPropertyConverter {
                             return nil
                         }
                         if values.count == 4 {
+                            // Style spec order: [top, right, bottom, left]
                             return NSExpression(forConstantValue: NSValue(
                                 uiEdgeInsets: UIEdgeInsets(
-                                    top: values[0], left: values[1],
-                                    bottom: values[2], right: values[3]
+                                    top: values[0], left: values[3],
+                                    bottom: values[2], right: values[1]
                                 )
                             ))
                         }
@@ -544,7 +545,7 @@ class LayerPropertyConverter {
                 // a proper Expression if the data is an array of double
                 return NSExpression(forConstantValue: [NSNumber(value: x), NSNumber(value: y)])
             } else if isEdgeInsets && offset.count == 4 {
-                // icon-text-fit-padding requires UIEdgeInsets, not an array of numbers
+                // icon-text-fit-padding requires UIEdgeInsets; style spec order is [top, right, bottom, left]
                 let values = offset.compactMap { element -> CGFloat? in
                     if let d = element as? Double { return CGFloat(d) }
                     if let i = element as? Int { return CGFloat(i) }
@@ -553,8 +554,8 @@ class LayerPropertyConverter {
                 if values.count == 4 {
                     return NSExpression(forConstantValue: NSValue(
                         uiEdgeInsets: UIEdgeInsets(
-                            top: values[0], left: values[1],
-                            bottom: values[2], right: values[3]
+                            top: values[0], left: values[3],
+                            bottom: values[2], right: values[1]
                         )
                     ))
                 }

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/LayerPropertyConverter.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/LayerPropertyConverter.swift
@@ -480,15 +480,16 @@ class LayerPropertyConverter {
         let isColor = propertyName.contains("color");
         let isOffset = propertyName.contains("offset");
         let isTranslate = propertyName.contains("translate");
+        let isEdgeInsets = propertyName == "icon-text-fit-padding";
 
         // The value is already in native format (not JSON string), use it directly
         let json = value
-        
+
         // Check if value is NSNull
         if json is NSNull {
             return nil
         }
-        
+
         // text-font is a font stack (array of string names), not an expression.
         if propertyName == "text-font", let fontNames = json as? [String] {
             return NSExpression(forConstantValue: fontNames)
@@ -506,6 +507,21 @@ class LayerPropertyConverter {
             // checks on the value of property that are literal expressions
             if offset.count == 2 && offset.first is String && offset.first as? String == "literal" {
                 if let vector = offset.last as? [Any]{
+                    if isEdgeInsets && vector.count == 4 {
+                        let values = vector.compactMap { element -> CGFloat? in
+                            if let d = element as? Double { return CGFloat(d) }
+                            if let i = element as? Int { return CGFloat(i) }
+                            return nil
+                        }
+                        if values.count == 4 {
+                            return NSExpression(forConstantValue: NSValue(
+                                uiEdgeInsets: UIEdgeInsets(
+                                    top: values[0], left: values[1],
+                                    bottom: values[2], right: values[3]
+                                )
+                            ))
+                        }
+                    }
                     if(vector.count == 2) {
                         if isOffset || isTranslate {
                             // this is required because NSExpression.init(mglJSONObject: json) fails to create
@@ -527,16 +543,36 @@ class LayerPropertyConverter {
                 // this is required because NSExpression.init(mglJSONObject: json) fails to create
                 // a proper Expression if the data is an array of double
                 return NSExpression(forConstantValue: [NSNumber(value: x), NSNumber(value: y)])
+            } else if isEdgeInsets && offset.count == 4 {
+                // icon-text-fit-padding requires UIEdgeInsets, not an array of numbers
+                let values = offset.compactMap { element -> CGFloat? in
+                    if let d = element as? Double { return CGFloat(d) }
+                    if let i = element as? Int { return CGFloat(i) }
+                    return nil
+                }
+                if values.count == 4 {
+                    return NSExpression(forConstantValue: NSValue(
+                        uiEdgeInsets: UIEdgeInsets(
+                            top: values[0], left: values[1],
+                            bottom: values[2], right: values[3]
+                        )
+                    ))
+                }
             } else {
                 // Handle arrays with any number of elements (e.g., dash arrays with 3+ elements)
                 // Convert to array of NSNumbers for proper expression creation
-                let numbers = offset.compactMap { $0 as? Double }.map { NSNumber(value: $0) }
+                let numbers = offset.compactMap { element -> NSNumber? in
+                    if let d = element as? Double { return NSNumber(value: d) }
+                    if let i = element as? Int { return NSNumber(value: i) }
+                    if let n = element as? NSNumber { return n }
+                    return nil
+                }
                 if numbers.count == offset.count {
                     return NSExpression(forConstantValue: numbers)
                 }
             }
         }
-        
+
         return NSExpression.init(mglJSONObject: json)
     }
 }

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/SourcePropertyConverter.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/SourcePropertyConverter.swift
@@ -168,7 +168,32 @@ class SourcePropertyConverter {
             options[.maximumZoomLevelForClustering] = clusterMaxZoom
         }
 
-        // TODO: clusterProperties not implemneted for IOS
+        if let clusterProperties = properties["clusterProperties"] as? [String: Any] {
+            var clusterPropertiesDict = [String: [NSExpression]]()
+            for (propertyName, value) in clusterProperties {
+                if let expressions = value as? [Any], expressions.count >= 2 {
+                    let operatorValue = expressions[0]
+                    let mapExpressionValue = expressions[1]
+
+                    // The operator can be either:
+                    // 1. A simple string like "+" — expand to ["+", ["accumulated"], ["get", propertyName]]
+                    // 2. A full reduce expression array like ["+", ["accumulated"], ["get", "sum"]]
+                    let operatorJSON: Any
+                    if let op = operatorValue as? String {
+                        operatorJSON = [op, ["accumulated"], ["get", propertyName]]
+                    } else {
+                        operatorJSON = operatorValue
+                    }
+
+                    let operatorExpr = NSExpression(mglJSONObject: operatorJSON)
+                    let mapExpr = NSExpression(mglJSONObject: mapExpressionValue)
+                    clusterPropertiesDict[propertyName] = [operatorExpr, mapExpr]
+                }
+            }
+            if !clusterPropertiesDict.isEmpty {
+                options[.clusterProperties] = clusterPropertiesDict
+            }
+        }
 
         if let lineMetrics = properties["lineMetrics"] as? Bool {
             options[.lineDistanceMetrics] = lineMetrics

--- a/maplibre_gl_example/lib/examples/layers/cluster_properties_example.dart
+++ b/maplibre_gl_example/lib/examples/layers/cluster_properties_example.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+import 'package:maplibre_gl/maplibre_gl.dart';
+import '../../page.dart';
+import '../../shared/shared.dart';
+
+/// Example demonstrating GeoJSON cluster properties.
+///
+/// Uses the USGS earthquakes dataset and aggregates two values across each
+/// cluster:
+///  * `max_mag` — the maximum magnitude of any earthquake in the cluster,
+///    declared with the *simple* operator-string form `["max", ["get", "mag"]]`.
+///  * `mag_sum` — the sum of magnitudes in the cluster, declared with the
+///    explicit reduce-expression form using `["accumulated"]`.
+///
+/// Both aggregates are displayed in the cluster label so the effect of
+/// clusterProperties is visible on screen.
+///
+/// Note: on iOS, complex expressions such as `case` used inside a cluster
+/// mapExpr can silently break the entire cluster property pipeline (including
+/// the built-in `point_count_abbreviated` becoming unavailable). Stick to
+/// straightforward numeric map expressions until this is fixed upstream.
+class ClusterPropertiesExample extends ExamplePage {
+  const ClusterPropertiesExample({super.key})
+    : super(
+        const Icon(Icons.hub_outlined),
+        'Cluster Properties',
+        category: ExampleCategory.layers,
+      );
+
+  @override
+  Widget build(BuildContext context) => const _ClusterPropertiesBody();
+}
+
+class _ClusterPropertiesBody extends StatefulWidget {
+  const _ClusterPropertiesBody();
+
+  @override
+  State<_ClusterPropertiesBody> createState() => _ClusterPropertiesBodyState();
+}
+
+class _ClusterPropertiesBodyState extends State<_ClusterPropertiesBody> {
+  static const _sourceId = 'earthquakes';
+
+  MapLibreMapController? _controller;
+
+  void _onMapCreated(MapLibreMapController controller) {
+    _controller = controller;
+  }
+
+  Future<void> _onStyleLoaded() async {
+    final controller = _controller;
+    if (controller == null) return;
+
+    await controller.addSource(
+      _sourceId,
+      const GeojsonSourceProperties(
+        data:
+            'https://maplibre.org/maplibre-gl-js/docs/assets/earthquakes.geojson',
+        cluster: true,
+        clusterRadius: 50,
+        clusterMaxZoom: 14,
+        clusterProperties: {
+          // Simple form: [operator, mapExpr].
+          'max_mag': ['max', ['get', 'mag']],
+          // Reduce-expression form: [fullReduceExpr, mapExpr].
+          'mag_sum': [
+            ['+', ['accumulated'], ['get', 'mag_sum']],
+            ['get', 'mag'],
+          ],
+        },
+        attribution:
+            '<a href="https://maplibre.org">Earthquake data © MapLibre</a>',
+      ),
+    );
+
+    await controller.addLayer(
+      _sourceId,
+      'earthquakes-cluster-circles',
+      const CircleLayerProperties(
+        circleColor: [
+          Expressions.step,
+          [Expressions.get, 'point_count'],
+          '#51bbd6',
+          100,
+          '#f1f075',
+          750,
+          '#f28cb1',
+        ],
+        circleRadius: [
+          Expressions.step,
+          [Expressions.get, 'point_count'],
+          22,
+          100,
+          30,
+          750,
+          38,
+        ],
+      ),
+      filter: ['has', 'point_count'],
+    );
+
+    // Label shows point count plus both aggregated values. Numeric values are
+    // rounded and coerced to string so concat receives only strings, which
+    // MapLibre iOS requires strictly.
+    await controller.addLayer(
+      _sourceId,
+      'earthquakes-cluster-labels',
+      const SymbolLayerProperties(
+        textField: [
+          Expressions.concat,
+          [Expressions.get, 'point_count_abbreviated'],
+          '\nmax ',
+          [
+            Expressions.toStringExpression,
+            // Round max_mag to one decimal: round(v * 10) / 10.
+            [
+              '/',
+              [
+                'round',
+                ['*', ['get', 'max_mag'], 10],
+              ],
+              10,
+            ],
+          ],
+          '\nsum ',
+          [
+            Expressions.toStringExpression,
+            ['round', ['get', 'mag_sum']],
+          ],
+        ],
+        textFont: ['Open Sans Semibold'],
+        textSize: 11,
+      ),
+      filter: ['has', 'point_count'],
+    );
+
+    await controller.addLayer(
+      _sourceId,
+      'earthquakes-unclustered',
+      const CircleLayerProperties(
+        circleColor: '#11b4da',
+        circleRadius: 4,
+        circleStrokeColor: '#fff',
+        circleStrokeWidth: 1,
+      ),
+      filter: [
+        '!',
+        ['has', 'point_count'],
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: MapLibreMap(
+        styleString: ExampleConstants.demoMapStyle,
+        onMapCreated: _onMapCreated,
+        onStyleLoadedCallback: _onStyleLoaded,
+        initialCameraPosition: const CameraPosition(
+          target: LatLng(33.5, -118.1),
+          zoom: 3,
+        ),
+      ),
+    );
+  }
+}

--- a/maplibre_gl_example/lib/examples/layers/cluster_properties_example.dart
+++ b/maplibre_gl_example/lib/examples/layers/cluster_properties_example.dart
@@ -61,10 +61,17 @@ class _ClusterPropertiesBodyState extends State<_ClusterPropertiesBody> {
         clusterMaxZoom: 14,
         clusterProperties: {
           // Simple form: [operator, mapExpr].
-          'max_mag': ['max', ['get', 'mag']],
+          'max_mag': [
+            'max',
+            ['get', 'mag'],
+          ],
           // Reduce-expression form: [fullReduceExpr, mapExpr].
           'mag_sum': [
-            ['+', ['accumulated'], ['get', 'mag_sum']],
+            [
+              '+',
+              ['accumulated'],
+              ['get', 'mag_sum'],
+            ],
             ['get', 'mag'],
           ],
         },
@@ -117,7 +124,11 @@ class _ClusterPropertiesBodyState extends State<_ClusterPropertiesBody> {
               '/',
               [
                 'round',
-                ['*', ['get', 'max_mag'], 10],
+                [
+                  '*',
+                  ['get', 'max_mag'],
+                  10,
+                ],
               ],
               10,
             ],
@@ -125,7 +136,10 @@ class _ClusterPropertiesBodyState extends State<_ClusterPropertiesBody> {
           '\nsum ',
           [
             Expressions.toStringExpression,
-            ['round', ['get', 'mag_sum']],
+            [
+              'round',
+              ['get', 'mag_sum'],
+            ],
           ],
         ],
         textFont: ['Open Sans Semibold'],

--- a/maplibre_gl_example/lib/main.dart
+++ b/maplibre_gl_example/lib/main.dart
@@ -35,6 +35,7 @@ import 'examples/annotations/edit_annotation_draggable.dart';
 
 // Layers examples
 import 'examples/layers/circle_layer_example.dart';
+import 'examples/layers/cluster_properties_example.dart';
 import 'examples/layers/fill_layer_example.dart';
 import 'examples/layers/line_layer_example.dart';
 import 'examples/layers/symbol_layer_example.dart';
@@ -117,6 +118,7 @@ final List<ExamplePage> _allPages = <ExamplePage>[
   // Layers
   const SymbolLayerExample(),
   const CircleLayerExample(),
+  const ClusterPropertiesExample(),
   const FillLayerExample(),
   const LineLayerExample(),
   const EditStyleLayerAnimatedExample(),

--- a/maplibre_gl_platform_interface/test/source_properties_test.dart
+++ b/maplibre_gl_platform_interface/test/source_properties_test.dart
@@ -223,6 +223,91 @@ void main() {
       expect(updated.cluster, true);
       expect(updated.buffer, 128); // preserved
     });
+
+    // clusterProperties is passed through as an opaque Object and serialized
+    // as-is. The native converters (Android Java, iOS Swift) interpret the
+    // two documented shapes: a simple operator-string form such as
+    // {'sum': ['+', ['get', 'scalerank']]}, or a full reduce-expression form
+    // such as {'sum': [['+', ['accumulated'], ['get', 'sum']], ['get', ...]]}.
+    // There is no native unit-test harness in this repo for those converters,
+    // so these tests only cover the Dart serialization contract. End-to-end
+    // behaviour is verified manually via the ClusterPropertiesExample page.
+    group('clusterProperties', () {
+      test('toJson passes through the simple operator-string form', () {
+        const props = GeojsonSourceProperties(
+          clusterProperties: {
+            'sum': ['+', ['get', 'scalerank']],
+          },
+        );
+        final json = props.toJson();
+        expect(json['clusterProperties'], {
+          'sum': ['+', ['get', 'scalerank']],
+        });
+      });
+
+      test('toJson passes through the reduce-expression form', () {
+        const props = GeojsonSourceProperties(
+          clusterProperties: {
+            'sum': [
+              ['+', ['accumulated'], ['get', 'sum']],
+              ['get', 'scalerank'],
+            ],
+          },
+        );
+        final json = props.toJson();
+        expect(json['clusterProperties'], {
+          'sum': [
+            ['+', ['accumulated'], ['get', 'sum']],
+            ['get', 'scalerank'],
+          ],
+        });
+      });
+
+      test('toJson omits clusterProperties when null', () {
+        const props = GeojsonSourceProperties();
+        final json = props.toJson();
+        expect(json.containsKey('clusterProperties'), isFalse);
+      });
+
+      test('fromJson/toJson roundtrip preserves clusterProperties', () {
+        const original = GeojsonSourceProperties(
+          cluster: true,
+          clusterProperties: {
+            'max_mag': ['max', ['get', 'mag']],
+            'tsunami_count': [
+              ['+', ['accumulated'], ['get', 'tsunami_count']],
+              ['case', ['==', ['get', 'tsunami'], 1], 1, 0],
+            ],
+          },
+        );
+        final restored = GeojsonSourceProperties.fromJson(original.toJson());
+        expect(restored.clusterProperties, original.clusterProperties);
+      });
+
+      test('copyWith updates clusterProperties', () {
+        const original = GeojsonSourceProperties(cluster: true);
+        final updated = original.copyWith(
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            'sum': ['+', ['get', 'weight']],
+          },
+          null,
+          null,
+          null,
+        );
+        expect(updated.clusterProperties, {
+          'sum': ['+', ['get', 'weight']],
+        });
+        expect(updated.cluster, true); // preserved
+      });
+    });
   });
 
   group('VideoSourceProperties', () {

--- a/maplibre_gl_platform_interface/test/source_properties_test.dart
+++ b/maplibre_gl_platform_interface/test/source_properties_test.dart
@@ -236,20 +236,8 @@ void main() {
       test('toJson passes through the simple operator-string form', () {
         const props = GeojsonSourceProperties(
           clusterProperties: {
-            'sum': ['+', ['get', 'scalerank']],
-          },
-        );
-        final json = props.toJson();
-        expect(json['clusterProperties'], {
-          'sum': ['+', ['get', 'scalerank']],
-        });
-      });
-
-      test('toJson passes through the reduce-expression form', () {
-        const props = GeojsonSourceProperties(
-          clusterProperties: {
             'sum': [
-              ['+', ['accumulated'], ['get', 'sum']],
+              '+',
               ['get', 'scalerank'],
             ],
           },
@@ -257,7 +245,33 @@ void main() {
         final json = props.toJson();
         expect(json['clusterProperties'], {
           'sum': [
-            ['+', ['accumulated'], ['get', 'sum']],
+            '+',
+            ['get', 'scalerank'],
+          ],
+        });
+      });
+
+      test('toJson passes through the reduce-expression form', () {
+        const props = GeojsonSourceProperties(
+          clusterProperties: {
+            'sum': [
+              [
+                '+',
+                ['accumulated'],
+                ['get', 'sum'],
+              ],
+              ['get', 'scalerank'],
+            ],
+          },
+        );
+        final json = props.toJson();
+        expect(json['clusterProperties'], {
+          'sum': [
+            [
+              '+',
+              ['accumulated'],
+              ['get', 'sum'],
+            ],
             ['get', 'scalerank'],
           ],
         });
@@ -273,10 +287,26 @@ void main() {
         const original = GeojsonSourceProperties(
           cluster: true,
           clusterProperties: {
-            'max_mag': ['max', ['get', 'mag']],
+            'max_mag': [
+              'max',
+              ['get', 'mag'],
+            ],
             'tsunami_count': [
-              ['+', ['accumulated'], ['get', 'tsunami_count']],
-              ['case', ['==', ['get', 'tsunami'], 1], 1, 0],
+              [
+                '+',
+                ['accumulated'],
+                ['get', 'tsunami_count'],
+              ],
+              [
+                'case',
+                [
+                  '==',
+                  ['get', 'tsunami'],
+                  1,
+                ],
+                1,
+                0,
+              ],
             ],
           },
         );
@@ -296,14 +326,20 @@ void main() {
           null,
           null,
           {
-            'sum': ['+', ['get', 'weight']],
+            'sum': [
+              '+',
+              ['get', 'weight'],
+            ],
           },
           null,
           null,
           null,
         );
         expect(updated.clusterProperties, {
-          'sum': ['+', ['get', 'weight']],
+          'sum': [
+            '+',
+            ['get', 'weight'],
+          ],
         });
         expect(updated.cluster, true); // preserved
       });

--- a/scripts/templates/LayerPropertyConverter.swift.template
+++ b/scripts/templates/LayerPropertyConverter.swift.template
@@ -78,15 +78,16 @@ class LayerPropertyConverter {
         let isColor = propertyName.contains("color");
         let isOffset = propertyName.contains("offset");
         let isTranslate = propertyName.contains("translate");
+        let isEdgeInsets = propertyName == "icon-text-fit-padding";
 
         // The value is already in native format (not JSON string), use it directly
         let json = value
-        
+
         // Check if value is NSNull
         if json is NSNull {
             return nil
         }
-        
+
         // text-font is a font stack (array of string names), not an expression.
         if propertyName == "text-font", let fontNames = json as? [String] {
             return NSExpression(forConstantValue: fontNames)
@@ -104,6 +105,21 @@ class LayerPropertyConverter {
             // checks on the value of property that are literal expressions
             if offset.count == 2 && offset.first is String && offset.first as? String == "literal" {
                 if let vector = offset.last as? [Any]{
+                    if isEdgeInsets && vector.count == 4 {
+                        let values = vector.compactMap { element -> CGFloat? in
+                            if let d = element as? Double { return CGFloat(d) }
+                            if let i = element as? Int { return CGFloat(i) }
+                            return nil
+                        }
+                        if values.count == 4 {
+                            return NSExpression(forConstantValue: NSValue(
+                                uiEdgeInsets: UIEdgeInsets(
+                                    top: values[0], left: values[1],
+                                    bottom: values[2], right: values[3]
+                                )
+                            ))
+                        }
+                    }
                     if(vector.count == 2) {
                         if isOffset || isTranslate {
                             // this is required because NSExpression.init(mglJSONObject: json) fails to create
@@ -125,16 +141,36 @@ class LayerPropertyConverter {
                 // this is required because NSExpression.init(mglJSONObject: json) fails to create
                 // a proper Expression if the data is an array of double
                 return NSExpression(forConstantValue: [NSNumber(value: x), NSNumber(value: y)])
+            } else if isEdgeInsets && offset.count == 4 {
+                // icon-text-fit-padding requires UIEdgeInsets, not an array of numbers
+                let values = offset.compactMap { element -> CGFloat? in
+                    if let d = element as? Double { return CGFloat(d) }
+                    if let i = element as? Int { return CGFloat(i) }
+                    return nil
+                }
+                if values.count == 4 {
+                    return NSExpression(forConstantValue: NSValue(
+                        uiEdgeInsets: UIEdgeInsets(
+                            top: values[0], left: values[1],
+                            bottom: values[2], right: values[3]
+                        )
+                    ))
+                }
             } else {
                 // Handle arrays with any number of elements (e.g., dash arrays with 3+ elements)
                 // Convert to array of NSNumbers for proper expression creation
-                let numbers = offset.compactMap { $0 as? Double }.map { NSNumber(value: $0) }
+                let numbers = offset.compactMap { element -> NSNumber? in
+                    if let d = element as? Double { return NSNumber(value: d) }
+                    if let i = element as? Int { return NSNumber(value: i) }
+                    if let n = element as? NSNumber { return n }
+                    return nil
+                }
                 if numbers.count == offset.count {
                     return NSExpression(forConstantValue: numbers)
                 }
             }
         }
-        
+
         return NSExpression.init(mglJSONObject: json)
     }
 }

--- a/scripts/templates/LayerPropertyConverter.swift.template
+++ b/scripts/templates/LayerPropertyConverter.swift.template
@@ -112,10 +112,11 @@ class LayerPropertyConverter {
                             return nil
                         }
                         if values.count == 4 {
+                            // Style spec order: [top, right, bottom, left]
                             return NSExpression(forConstantValue: NSValue(
                                 uiEdgeInsets: UIEdgeInsets(
-                                    top: values[0], left: values[1],
-                                    bottom: values[2], right: values[3]
+                                    top: values[0], left: values[3],
+                                    bottom: values[2], right: values[1]
                                 )
                             ))
                         }
@@ -142,7 +143,7 @@ class LayerPropertyConverter {
                 // a proper Expression if the data is an array of double
                 return NSExpression(forConstantValue: [NSNumber(value: x), NSNumber(value: y)])
             } else if isEdgeInsets && offset.count == 4 {
-                // icon-text-fit-padding requires UIEdgeInsets, not an array of numbers
+                // icon-text-fit-padding requires UIEdgeInsets; style spec order is [top, right, bottom, left]
                 let values = offset.compactMap { element -> CGFloat? in
                     if let d = element as? Double { return CGFloat(d) }
                     if let i = element as? Int { return CGFloat(i) }
@@ -151,8 +152,8 @@ class LayerPropertyConverter {
                 if values.count == 4 {
                     return NSExpression(forConstantValue: NSValue(
                         uiEdgeInsets: UIEdgeInsets(
-                            top: values[0], left: values[1],
-                            bottom: values[2], right: values[3]
+                            top: values[0], left: values[3],
+                            bottom: values[2], right: values[1]
                         )
                     ))
                 }


### PR DESCRIPTION
 The Dart platform interface already defines clusterProperties in GeojsonSourceProperties and correctly serializes it via toJson(), but neither the Android nor iOS native implementations actually handled this property. On iOS, there was an explicit // TODO: clusterProperties 
  not implemneted for IOS placeholder. On Android, the property was simply ignored.                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                     
  This meant that users setting clusterProperties on a clustered GeoJSON source (e.g. to aggregate values like sums or counts across clusters) had no effect on Android or iOS — only the web platform worked.                                                                   
                                                                                                                                                                                                                                                                                     
  Additionally, the iOS LayerPropertyConverter had two related bugs:                                                                                                                                                                                                                 
  1. The icon-text-fit-padding property requires UIEdgeInsets but was being passed as a plain number array, causing it to be ignored by MapLibre.                                                                                                                                    
  2. Numeric arrays (e.g. dash patterns) only handled Double values, failing silently when the platform channel delivered Int values.                                                                                                                                                
                                                                                                                                                                                                                                                                                     
  Changes                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                     
  Android (SourcePropertyConverter.java)                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                 
  - Parse clusterProperties map entries as [operator, map_expression] pairs
  - Convert them to MapLibre Expression objects via Gson/JsonParser                                                                                                                                                                                                                  
  - Validate entry types and list sizes before accessing elements                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                     
  iOS (SourcePropertyConverter.swift)                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                 
  - Replace TODO placeholder with full clusterProperties implementation using NSExpression
  - Support both simple operator strings (e.g. "+") that get expanded to reduce expressions, and full reduce expression arrays                                                                                                                                                       
                                                                                                                                                                                                                                                                                     
  iOS (LayerPropertyConverter.swift)                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                     
  - Fix icon-text-fit-padding to correctly produce UIEdgeInsets instead of a plain number array (handles both literal and non-literal expression paths)                                                                                                                              
  - Improve numeric type handling in array expressions to support Int and NSNumber in addition to Double                                                                                                                                                                             
                                                                                                                                                                                                                                                                                     
  Example app (project.pbxproj)                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                     
  - Align iOS deployment target from 12.0 to 13.0 to match the podspec requirement         