### PR TITLE
feat: enhance Offline Regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ Use Platform-specific constructors: `LocationEnginePlatforms.android()`, `.iOS()
 * `featureTapsTriggersMapClick` option to control whether feature taps also trigger map click callbacks, defaults to `false` (#729).
 * Fire `onMapClick` for all map taps, including after interactive features (#707).
 * Unit tests for core packages (#765).
+* **Offline Regions**: richer control and observability over downloads on Android and iOS (#795).
+  * `pauseOfflineRegionDownload` / `resumeOfflineRegionDownload` to control in-progress downloads.
+  * `getOfflineRegionStatus` returning `OfflineRegionStatus` with resource counts, bytes, progress and completion.
+  * `InProgress` events now carry `completedResourceCount`, `requiredResourceCount`, and `completedResourceSize` for tile/byte progress in addition to the percentage.
+  * `clearAmbientCache` and `resetOfflineDatabase` globals to evict unpinned tiles or fully reset the offline DB (in-flight downloads are terminated Dart-side before reset/deletion).
+  * `setOfflineMaxConcurrentRequests` to cap tile concurrency (total on Android, per-host on both) and avoid upstream rate limiting.
 * **iOS**: Implemented `setMaximumFps` to control the preferred frame rate (#739).
 * **Android**: Google Mobile Services (GMS) Location Engine support (#721).
 * **Web**: Exposed `onMouseMove` and added feature state management (`setFeatureState`, `getFeatureState`, `removeFeatureState`) (#718).
@@ -60,6 +66,9 @@ Use Platform-specific constructors: `LocationEnginePlatforms.android()`, `.iOS()
 * **Android**: GeoJSON source updates are now synchronous when drag is enabled, preventing stale feature positions during drag interactions and improved performance (#716).
 * **Android**: Disabled texture mode by default and improved MapView lifecycle management (#723).
 * **Android**: Removed unnecessary `OfflineActivity` from `AndroidManifest.xml` (#724).
+* **Offline Regions**: retain download `StreamSubscription`s in a module-level map so Dart's GC can't drop native events while a download is paused (#795).
+* **Android (Offline)**: throttle progress events to 100ms and discard non-monotonic counts so cache-served bursts don't starve the isolate and block pause taps; track in-flight downloads to support pause/resume/status (#795).
+* **iOS (Offline)**: track active `MLNOfflinePack` instances so pause/resume/status operate on the live pack rather than reloading from storage (#795).
 * **iOS**: Deferred `onStyleLoaded` callback to avoid race conditions (#719).
 * **Web**: Improved `styleimagemissing` handling (#725).
 * **Web**: Fixed JS Interop and WASM compilation in release mode (#714).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,10 +37,10 @@ Use Platform-specific constructors: `LocationEnginePlatforms.android()`, `.iOS()
 * **Android**: Enhanced GeoJSON source handling with type checks and error logging (#764).
 * **Android**: Check style exists and is loaded before adding a Layer (#768).
 * **Android**: Check source exists before adding (#734).
-* **Android**: MapLibre Android SDK upgraded from 13.0.0 to 13.0.1, switched to OpenGL renderer variant (`android-sdk-opengl`) for better stability and performance on older devices.
+* **Android**: MapLibre Android SDK upgraded from 13.0.0 to 13.0.2, switched to OpenGL renderer variant (`android-sdk-opengl`) for better stability and performance on older devices.
 * **iOS**: Updated project settings for UISceneDelegate compatibility (#767).
-* **iOS**: MapLibre iOS SDK upgraded from 6.19.1 to 6.24.0.
-* **Web**: Upgraded MapLibre GL JS from 4.7.1 to [5.21.0](https://github.com/maplibre/maplibre-gl-js/releases/tag/v5.21.0) (#761, #651).
+* **iOS**: MapLibre iOS SDK upgraded from 6.19.1 to 6.25.1.
+* **Web**: Upgraded MapLibre GL JS from 4.7.1 to [5.24.0](https://github.com/maplibre/maplibre-gl-js/releases/tag/v5.21.0) (#761, #651).
 * **Web**: Migrated `preserveDrawingBuffer`, `antialias`, and `failIfMajorPerformanceCaveat` from top-level `MapOptions` to `canvasContextAttributes`.
 * **Web**: Updated `on()`/`off()`/`once()` event methods to handle v5's `Subscription` return type instead of map instance.
 * **Web**: Removed obsolete `customAttribution` from `MapOptions` (now part of `AttributionControl` options in v5).

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -30,10 +30,10 @@ Use Platform-specific constructors: `LocationEnginePlatforms.android()`, `.iOS()
 * **Android**: Enhanced GeoJSON source handling with type checks and error logging (#764).
 * **Android**: Check style exists and is loaded before adding a Layer (#768).
 * **Android**: Check source exists before adding (#734).
-* **Android**: MapLibre Android SDK upgraded from 13.0.0 to 13.0.1, switched to OpenGL renderer variant (`android-sdk-opengl`) for better stability and performance on older devices.
+* **Android**: MapLibre Android SDK upgraded from 13.0.0 to 13.0.2, switched to OpenGL renderer variant (`android-sdk-opengl`) for better stability and performance on older devices.
 * **iOS**: Updated project settings for UISceneDelegate compatibility (#767).
-* **iOS**: MapLibre iOS SDK upgraded from 6.19.1 to 6.24.0.
-* **Web**: Upgraded MapLibre GL JS from 4.7.1 to [5.21.0](https://github.com/maplibre/maplibre-gl-js/releases/tag/v5.21.0) (#761, #651).
+* **iOS**: MapLibre iOS SDK upgraded from 6.19.1 to 6.25.1.
+* **Web**: Upgraded MapLibre GL JS from 4.7.1 to [5.24.0](https://github.com/maplibre/maplibre-gl-js/releases/tag/v5.21.0) (#761, #651).
 * **Web**: Migrated `preserveDrawingBuffer`, `antialias`, and `failIfMajorPerformanceCaveat` from top-level `MapOptions` to `canvasContextAttributes`.
 * **Web**: Updated `on()`/`off()`/`once()` event methods to handle v5's `Subscription` return type instead of map instance.
 * **Web**: Removed obsolete `customAttribution` from `MapOptions` (now part of `AttributionControl` options in v5).

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -16,6 +16,12 @@ Use Platform-specific constructors: `LocationEnginePlatforms.android()`, `.iOS()
 * `featureTapsTriggersMapClick` option to control whether feature taps also trigger map click callbacks, defaults to `false` (#729).
 * Fire `onMapClick` for all map taps, including after interactive features (#707).
 * Unit tests for core packages (#765).
+* **Offline Regions**: richer control and observability over downloads on Android and iOS (#795).
+  * `pauseOfflineRegionDownload` / `resumeOfflineRegionDownload` to control in-progress downloads.
+  * `getOfflineRegionStatus` returning `OfflineRegionStatus` with resource counts, bytes, progress and completion.
+  * `InProgress` events now carry `completedResourceCount`, `requiredResourceCount`, and `completedResourceSize` for tile/byte progress in addition to the percentage.
+  * `clearAmbientCache` and `resetOfflineDatabase` globals to evict unpinned tiles or fully reset the offline DB (in-flight downloads are terminated Dart-side before reset/deletion).
+  * `setOfflineMaxConcurrentRequests` to cap tile concurrency (total on Android, per-host on both) and avoid upstream rate limiting.
 * **iOS**: Implemented `setMaximumFps` to control the preferred frame rate (#739).
 * **Android**: Google Mobile Services (GMS) Location Engine support (#721).
 * **Web**: Exposed `onMouseMove` and added feature state management (`setFeatureState`, `getFeatureState`, `removeFeatureState`) (#718).
@@ -53,6 +59,9 @@ Use Platform-specific constructors: `LocationEnginePlatforms.android()`, `.iOS()
 * **Android**: GeoJSON source updates are now synchronous when drag is enabled, preventing stale feature positions during drag interactions and improved performance (#716).
 * **Android**: Disabled texture mode by default and improved MapView lifecycle management (#723).
 * **Android**: Removed unnecessary `OfflineActivity` from `AndroidManifest.xml` (#724).
+* **Offline Regions**: retain download `StreamSubscription`s in a module-level map so Dart's GC can't drop native events while a download is paused (#795).
+* **Android (Offline)**: throttle progress events to 100ms and discard non-monotonic counts so cache-served bursts don't starve the isolate and block pause taps; track in-flight downloads to support pause/resume/status (#795).
+* **iOS (Offline)**: track active `MLNOfflinePack` instances so pause/resume/status operate on the live pack rather than reloading from storage (#795).
 * **iOS**: Deferred `onStyleLoaded` callback to avoid race conditions (#719).
 * **Web**: Improved `styleimagemissing` handling (#725).
 * **Web**: Fixed JS Interop and WASM compilation in release mode (#714).

--- a/maplibre_gl/android/build.gradle
+++ b/maplibre_gl/android/build.gradle
@@ -57,7 +57,7 @@ android {
     dependencies {
         // Using OpenGL instead of new Vulkan-based renderer for now, as it is more stable and has better performance on older devices.
         // If we want to use the Vulkan-based renderer in the future, we can switch to the regular SDK dependency below and remove the exclusion above.
-        implementation 'org.maplibre.gl:android-sdk-opengl:13.0.1'
+        implementation 'org.maplibre.gl:android-sdk-opengl:13.0.2'
         implementation 'org.maplibre.gl:android-plugin-annotation-v9:3.0.2'
         implementation 'org.maplibre.gl:android-plugin-offline-v9:3.0.2'
         implementation 'com.squareup.okhttp3:okhttp:5.3.2'

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/GlobalMethodHandler.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/GlobalMethodHandler.java
@@ -125,6 +125,34 @@ class GlobalMethodHandler implements MethodChannel.MethodCallHandler {
         OfflineManagerUtils.deleteRegion(
             result, context, methodCall.<Number>argument("id").longValue());
         break;
+      case "clearAmbientCache":
+        OfflineManagerUtils.clearAmbientCache(result, context);
+        break;
+      case "resetOfflineDatabase":
+        OfflineManagerUtils.resetOfflineDatabase(result, context);
+        break;
+      case "pauseOfflineRegionDownload":
+        OfflineManagerUtils.pauseRegion(
+            result, context, methodCall.<Number>argument("id").longValue());
+        break;
+      case "resumeOfflineRegionDownload":
+        OfflineManagerUtils.resumeRegion(
+            result, context, methodCall.<Number>argument("id").longValue());
+        break;
+      case "getOfflineRegionStatus":
+        OfflineManagerUtils.getRegionStatus(
+            result, context, methodCall.<Number>argument("id").longValue());
+        break;
+      case "setOfflineMaxConcurrentRequests":
+        {
+          Number maxRequestsNum = methodCall.argument("maxRequests");
+          Number maxRequestsPerHostNum = methodCall.argument("maxRequestsPerHost");
+          Integer maxRequests = maxRequestsNum != null ? maxRequestsNum.intValue() : null;
+          Integer maxRequestsPerHost =
+              maxRequestsPerHostNum != null ? maxRequestsPerHostNum.intValue() : null;
+          MapLibreHttpRequestUtil.setMaxConcurrentRequests(maxRequests, maxRequestsPerHost, result);
+          break;
+        }
       default:
         result.notImplemented();
         break;

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreHttpRequestUtil.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreHttpRequestUtil.java
@@ -3,41 +3,64 @@ package org.maplibre.maplibregl;
 import org.maplibre.android.module.http.HttpRequestUtil;
 import io.flutter.plugin.common.MethodChannel;
 import java.util.Map;
+import okhttp3.Dispatcher;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 
 abstract class MapLibreHttpRequestUtil {
 
+  private static Map<String, String> currentHeaders;
+  private static Integer currentMaxRequests;
+  private static Integer currentMaxRequestsPerHost;
+
   public static void setHttpHeaders(Map<String, String> headers, MethodChannel.Result result) {
-    HttpRequestUtil.setOkHttpClient(getOkHttpClient(headers, result).build());
+    currentHeaders = headers;
+    rebuildClient();
     result.success(null);
   }
 
-  private static OkHttpClient.Builder getOkHttpClient(
-      Map<String, String> headers, MethodChannel.Result result) {
-    try {
-      return new OkHttpClient.Builder()
-          .addNetworkInterceptor(
-              chain -> {
-                Request.Builder builder = chain.request().newBuilder();
-                for (Map.Entry<String, String> header : headers.entrySet()) {
-                  if (header.getKey() == null || header.getKey().trim().isEmpty()) {
-                    continue;
-                  }
-                  if (header.getValue() == null || header.getValue().trim().isEmpty()) {
-                    builder.removeHeader(header.getKey());
-                  } else {
-                    builder.header(header.getKey(), header.getValue());
-                  }
-                }
-                return chain.proceed(builder.build());
-              });
-    } catch (Exception e) {
-      result.error(
-          "OK_HTTP_CLIENT_ERROR",
-          "An unexcepted error happened during creating http " + "client" + e.getMessage(),
-          null);
-      throw new RuntimeException(e);
+  public static void setMaxConcurrentRequests(
+      Integer maxRequests, Integer maxRequestsPerHost, MethodChannel.Result result) {
+    currentMaxRequests = maxRequests;
+    currentMaxRequestsPerHost = maxRequestsPerHost;
+    rebuildClient();
+    result.success(null);
+  }
+
+  private static void rebuildClient() {
+    OkHttpClient.Builder builder = new OkHttpClient.Builder();
+
+    // Apply dispatcher configuration
+    if (currentMaxRequests != null || currentMaxRequestsPerHost != null) {
+      Dispatcher dispatcher = new Dispatcher();
+      if (currentMaxRequests != null) {
+        dispatcher.setMaxRequests(currentMaxRequests);
+      }
+      if (currentMaxRequestsPerHost != null) {
+        dispatcher.setMaxRequestsPerHost(currentMaxRequestsPerHost);
+      }
+      builder.dispatcher(dispatcher);
     }
+
+    // Apply header interceptor
+    if (currentHeaders != null) {
+      builder.addNetworkInterceptor(
+          chain -> {
+            Request.Builder reqBuilder = chain.request().newBuilder();
+            for (Map.Entry<String, String> header : currentHeaders.entrySet()) {
+              if (header.getKey() == null || header.getKey().trim().isEmpty()) {
+                continue;
+              }
+              if (header.getValue() == null || header.getValue().trim().isEmpty()) {
+                reqBuilder.removeHeader(header.getKey());
+              } else {
+                reqBuilder.header(header.getKey(), header.getValue());
+              }
+            }
+            return chain.proceed(reqBuilder.build());
+          });
+    }
+
+    HttpRequestUtil.setOkHttpClient(builder.build());
   }
 }

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/OfflineChannelHandlerImpl.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/OfflineChannelHandlerImpl.java
@@ -45,11 +45,18 @@ public class OfflineChannelHandlerImpl implements EventChannel.StreamHandler {
     sink.success(gson.toJson(body));
   }
 
-  void onProgress(double progress) {
+  void onProgress(
+      double progress,
+      long completedResourceCount,
+      long requiredResourceCount,
+      long completedResourceSize) {
     if (sink == null) return;
     Map<String, Object> body = new HashMap<>();
     body.put("status", "progress");
     body.put("progress", progress);
+    body.put("completedResourceCount", completedResourceCount);
+    body.put("requiredResourceCount", requiredResourceCount);
+    body.put("completedResourceSize", completedResourceSize);
     sink.success(gson.toJson(body));
   }
 }

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/OfflineManagerUtils.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/OfflineManagerUtils.java
@@ -1,7 +1,9 @@
 package org.maplibre.maplibregl;
 
 import android.content.Context;
+import android.os.SystemClock;
 import android.util.Log;
+import androidx.annotation.NonNull;
 import com.google.gson.Gson;
 import org.maplibre.android.geometry.LatLng;
 import org.maplibre.android.geometry.LatLngBounds;
@@ -21,6 +23,35 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 abstract class OfflineManagerUtils {
   private static final String TAG = "OfflineManagerUtils";
+
+  /**
+   * Minimum interval between progress events forwarded to Dart. When tiles are
+   * served from the local MapLibre cache (e.g. a previously downloaded region
+   * was deleted and re-downloaded), the SDK can emit ~1000 status updates per
+   * second, flooding the Dart isolate and starving user input (pause/resume
+   * taps). Terminal events (completion, error) are always emitted regardless
+   * of this throttle.
+   */
+  private static final long PROGRESS_EMIT_MIN_INTERVAL_MS = 100L;
+
+  /** Holds the state needed to observe and control an in-progress download. */
+  static class ActiveDownload {
+    final OfflineRegion region;
+    final OfflineChannelHandlerImpl channelHandler;
+    final AtomicBoolean isComplete;
+    long lastProgressEmitMs;
+    long lastEmittedCompletedCount;
+
+    ActiveDownload(OfflineRegion region, OfflineChannelHandlerImpl channelHandler, AtomicBoolean isComplete) {
+      this.region = region;
+      this.channelHandler = channelHandler;
+      this.isComplete = isComplete;
+      this.lastProgressEmitMs = 0L;
+      this.lastEmittedCompletedCount = -1L;
+    }
+  }
+
+  static final Map<Long, ActiveDownload> activeDownloads = new HashMap<>();
 
   static void mergeRegions(MethodChannel.Result result, Context context, String path) {
     OfflineManager.Companion.getInstance(context)
@@ -49,6 +80,129 @@ abstract class OfflineManagerUtils {
     result.success(null);
   }
 
+  static void clearAmbientCache(MethodChannel.Result result, Context context) {
+    OfflineManager.Companion.getInstance(context)
+        .clearAmbientCache(
+            new OfflineManager.FileSourceCallback() {
+              @Override
+              public void onSuccess() {
+                result.success(null);
+              }
+
+              @Override
+              public void onError(@NonNull String message) {
+                result.error("ClearAmbientCacheError", message, null);
+              }
+            });
+  }
+
+  static void resetOfflineDatabase(MethodChannel.Result result, Context context) {
+    // Any tracked in-progress downloads are invalidated by the reset.
+    for (ActiveDownload ad : activeDownloads.values()) {
+      ad.isComplete.set(true);
+      try {
+        ad.region.setDownloadState(OfflineRegion.STATE_INACTIVE);
+      } catch (Throwable ignored) {
+        // Region may already be invalid; ignore.
+      }
+    }
+    activeDownloads.clear();
+
+    OfflineManager.Companion.getInstance(context)
+        .resetDatabase(
+            new OfflineManager.FileSourceCallback() {
+              @Override
+              public void onSuccess() {
+                result.success(null);
+              }
+
+              @Override
+              public void onError(@NonNull String message) {
+                result.error("ResetDatabaseError", message, null);
+              }
+            });
+  }
+
+  /**
+   * Creates and sets an {@link OfflineRegion.OfflineRegionObserver} on the given region.
+   * The observer forwards progress, completion, and error events to the channel handler.
+   */
+  private static void setObserverOnRegion(
+      OfflineRegion region, OfflineChannelHandlerImpl channelHandler,
+      AtomicBoolean isComplete, Context context) {
+    OfflineRegion.OfflineRegionObserver observer =
+        new OfflineRegion.OfflineRegionObserver() {
+          @Override
+          public void onStatusChanged(OfflineRegionStatus status) {
+            double progress =
+                calculateDownloadingProgress(
+                    status.getRequiredResourceCount(),
+                    status.getCompletedResourceCount());
+            if (status.isComplete()) {
+              if (isComplete.get()) return;
+              isComplete.set(true);
+              region.setDownloadState(OfflineRegion.STATE_INACTIVE);
+              activeDownloads.remove(region.getId());
+              channelHandler.onSuccess();
+              return;
+            }
+            // Throttle: when tiles come from cache, the SDK fires hundreds of
+            // updates per second and floods the Dart isolate, preventing user
+            // input (pause taps) from being processed in a timely manner.
+            ActiveDownload ad = activeDownloads.get(region.getId());
+            long now = SystemClock.uptimeMillis();
+            if (ad != null
+                && ad.lastProgressEmitMs != 0L
+                && now - ad.lastProgressEmitMs < PROGRESS_EMIT_MIN_INTERVAL_MS) {
+              return;
+            }
+            // Drop non-monotonic counts. After pause/resume the SDK may fire
+            // a transient onStatusChanged with a stale zero count before it
+            // reconciles, which would otherwise make the UI flash back to 0%.
+            long completed = status.getCompletedResourceCount();
+            if (ad != null
+                && ad.lastEmittedCompletedCount >= 0L
+                && completed < ad.lastEmittedCompletedCount) {
+              return;
+            }
+            if (ad != null) {
+              ad.lastProgressEmitMs = now;
+              ad.lastEmittedCompletedCount = completed;
+            }
+            channelHandler.onProgress(
+                progress,
+                status.getCompletedResourceCount(),
+                status.getRequiredResourceCount(),
+                status.getCompletedResourceSize());
+          }
+
+          @Override
+          public void onError(OfflineRegionError error) {
+            Log.e(TAG, "onError reason: " + error.getReason());
+            Log.e(TAG, "onError message: " + error.getMessage());
+            region.setDownloadState(OfflineRegion.STATE_INACTIVE);
+            activeDownloads.remove(region.getId());
+            isComplete.set(true);
+            channelHandler.onError(
+                "Downloading error", error.getMessage(), error.getReason());
+          }
+
+          @Override
+          public void mapboxTileCountLimitExceeded(long limit) {
+            Log.e(TAG, "MapLibre tile count limit exceeded: " + limit);
+            region.setDownloadState(OfflineRegion.STATE_INACTIVE);
+            activeDownloads.remove(region.getId());
+            isComplete.set(true);
+            channelHandler.onError(
+                "mapboxTileCountLimitExceeded",
+                "MapLibre tile count limit exceeded: " + limit,
+                null);
+            deleteRegion(null, context, region.getId());
+          }
+        };
+    region.setObserver(observer);
+  }
+
   static void downloadRegion(
       MethodChannel.Result result,
       Context context,
@@ -72,88 +226,22 @@ abstract class OfflineManagerUtils {
 
               @Override
               public void onCreate(OfflineRegion offlineRegion) {
+                _offlineRegion = offlineRegion;
+                // Track BEFORE result.success so the Dart side can't race us by
+                // invoking pause/resume before this region is registered.
+                activeDownloads.put(offlineRegion.getId(),
+                    new ActiveDownload(offlineRegion, channelHandler, isComplete));
+                setObserverOnRegion(offlineRegion, channelHandler, isComplete, context);
+                _offlineRegion.setDownloadState(OfflineRegion.STATE_ACTIVE);
+
                 Map<String, Object> regionData = offlineRegionToMap(offlineRegion);
                 result.success(new Gson().toJson(regionData));
-
-                _offlineRegion = offlineRegion;
-                // Observe downloading state
-                OfflineRegion.OfflineRegionObserver observer =
-                    new OfflineRegion.OfflineRegionObserver() {
-                      @Override
-                      public void onStatusChanged(OfflineRegionStatus status) {
-                        // Calculate progress of
-                        // downloading
-                        double progress =
-                            calculateDownloadingProgress(
-                                status.getRequiredResourceCount(),
-                                status.getCompletedResourceCount());
-                        // Check if downloading is
-                        // complete
-                        if (status.isComplete()) {
-                          Log.i(TAG, "Region " + "downloaded " + "successfully.");
-                          // Reset downloading state
-                          _offlineRegion.setDownloadState(OfflineRegion.STATE_INACTIVE);
-                          // This can be called
-                          // multiple times, and
-                          // result can be called
-                          // only once,
-                          // so there is need to
-                          // prevent it
-                          if (isComplete.get()) return;
-                          isComplete.set(true);
-                          channelHandler.onSuccess();
-                        } else {
-                          Log.i(TAG, "Region " + "download " + "progress = " + progress);
-                          channelHandler.onProgress(progress);
-                        }
-                      }
-
-                      @Override
-                      public void onError(OfflineRegionError error) {
-                        Log.e(TAG, "onError reason: " + error.getReason());
-                        Log.e(TAG, "onError message: " + error.getMessage());
-                        // Reset downloading state
-                        _offlineRegion.setDownloadState(OfflineRegion.STATE_INACTIVE);
-                        isComplete.set(true);
-                        channelHandler.onError(
-                            "Downloading error", error.getMessage(), error.getReason());
-                      }
-
-                      @Override
-                      public void mapboxTileCountLimitExceeded(long limit) {
-                        Log.e(TAG, "MapLibre tile count" + " limit exceeded: " + limit);
-                        // Reset downloading state
-                        _offlineRegion.setDownloadState(OfflineRegion.STATE_INACTIVE);
-                        isComplete.set(true);
-                        channelHandler.onError(
-                            "mapboxTileCountLimitExceeded",
-                            "MapLibre tile count " + "limit " + "exceeded: " + limit,
-                            null);
-                        // MapLibre even after crash
-                        // and not downloading fully
-                        // region still keeps part
-                        // of it in database, so we
-                        // have to remove it
-                        deleteRegion(null, context, _offlineRegion.getId());
-                      }
-                    };
-
-                _offlineRegion.setObserver(observer);
-
-                // Start downloading region
-                _offlineRegion.setDownloadState(OfflineRegion.STATE_ACTIVE);
                 channelHandler.onStart();
               }
 
-              /**
-               * This will be call if given region definition is invalid
-               *
-               * @param error
-               */
               @Override
               public void onError(String error) {
                 Log.e(TAG, "Error: " + error);
-                // Reset downloading state
                 _offlineRegion.setDownloadState(OfflineRegion.STATE_INACTIVE);
                 channelHandler.onError("mapboxInvalidRegionDefinition", error, null);
                 result.error("mapboxInvalidRegionDefinition", error, null);
@@ -231,6 +319,11 @@ abstract class OfflineManagerUtils {
   }
 
   static void deleteRegion(MethodChannel.Result result, Context context, long id) {
+    ActiveDownload active = activeDownloads.remove(id);
+    if (active != null) {
+      active.isComplete.set(true);
+      active.region.setDownloadState(OfflineRegion.STATE_INACTIVE);
+    }
     OfflineManager.Companion.getInstance(context)
         .listOfflineRegions(
             new OfflineManager.ListOfflineRegionsCallback() {
@@ -268,6 +361,123 @@ abstract class OfflineManagerUtils {
                 result.error("RegionListError", error, null);
               }
             });
+  }
+
+  // Pause / Resume / Status
+
+  static void pauseRegion(MethodChannel.Result result, Context context, long id) {
+    ActiveDownload download = activeDownloads.get(id);
+    if (download != null) {
+      download.region.setDownloadState(OfflineRegion.STATE_INACTIVE);
+      result.success(null);
+    } else {
+      findRegionById(context, id, result, "PauseRegionError", foundRegion -> {
+        foundRegion.setDownloadState(OfflineRegion.STATE_INACTIVE);
+        result.success(null);
+      });
+    }
+  }
+
+  static void resumeRegion(MethodChannel.Result result, Context context, long id) {
+    ActiveDownload download = activeDownloads.get(id);
+    if (download != null) {
+      // Deliver status messages even while inactive so the state-change
+      // callback fires after STATE_ACTIVE — some paths rely on this to
+      // re-arm internal tile dispatching.
+      download.region.setDeliverInactiveMessages(true);
+      // Re-set the observer to ensure callbacks fire after resume
+      setObserverOnRegion(download.region, download.channelHandler, download.isComplete, context);
+      download.region.setDownloadState(OfflineRegion.STATE_ACTIVE);
+      result.success(null);
+    } else {
+      findRegionById(context, id, result, "ResumeRegionError", foundRegion -> {
+        // Region was not tracked (e.g. app restarted) — we cannot resume
+        // progress events without a channel handler, so return an error.
+        result.error(
+            "ResumeRegionError",
+            "Region is no longer actively tracked. Please restart the download.",
+            null);
+      });
+    }
+  }
+
+  private interface RegionCallback {
+    void onFound(OfflineRegion region);
+  }
+
+  private static void findRegionById(
+      Context context, long id, MethodChannel.Result result, String errorCode, RegionCallback callback) {
+    OfflineManager.Companion.getInstance(context)
+        .listOfflineRegions(
+            new OfflineManager.ListOfflineRegionsCallback() {
+              @Override
+              public void onList(OfflineRegion[] offlineRegions) {
+                for (OfflineRegion offlineRegion : offlineRegions) {
+                  if (offlineRegion.getId() != id) continue;
+                  callback.onFound(offlineRegion);
+                  return;
+                }
+                result.error(errorCode, "There is no region with given id", null);
+              }
+
+              @Override
+              public void onError(String error) {
+                result.error(errorCode, error, null);
+              }
+            });
+  }
+
+  static void getRegionStatus(MethodChannel.Result result, Context context, long id) {
+    // Check active downloads first
+    ActiveDownload download = activeDownloads.get(id);
+    if (download != null) {
+      fetchAndReturnStatus(result, download.region);
+      return;
+    }
+    // Fall back to listing all regions
+    OfflineManager.Companion.getInstance(context)
+        .listOfflineRegions(
+            new OfflineManager.ListOfflineRegionsCallback() {
+              @Override
+              public void onList(OfflineRegion[] offlineRegions) {
+                for (OfflineRegion offlineRegion : offlineRegions) {
+                  if (offlineRegion.getId() != id) continue;
+                  fetchAndReturnStatus(result, offlineRegion);
+                  return;
+                }
+                result.error(
+                    "GetRegionStatusError", "There is no region with given id", null);
+              }
+
+              @Override
+              public void onError(String error) {
+                result.error("GetRegionStatusError", error, null);
+              }
+            });
+  }
+
+  private static void fetchAndReturnStatus(MethodChannel.Result result, OfflineRegion region) {
+    region.getStatus(
+        new OfflineRegion.OfflineRegionStatusCallback() {
+          @Override
+          public void onStatus(OfflineRegionStatus status) {
+            double progress =
+                calculateDownloadingProgress(
+                    status.getRequiredResourceCount(), status.getCompletedResourceCount());
+            Map<String, Object> statusMap = new HashMap<>();
+            statusMap.put("completedResourceCount", status.getCompletedResourceCount());
+            statusMap.put("requiredResourceCount", status.getRequiredResourceCount());
+            statusMap.put("completedResourceSize", status.getCompletedResourceSize());
+            statusMap.put("isComplete", status.isComplete());
+            statusMap.put("downloadProgress", progress);
+            result.success(new Gson().toJson(statusMap));
+          }
+
+          @Override
+          public void onError(String error) {
+            result.error("GetRegionStatusError", error, null);
+          }
+        });
   }
 
   private static double calculateDownloadingProgress(

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/OfflineManagerUtils.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/OfflineManagerUtils.java
@@ -105,6 +105,12 @@ abstract class OfflineManagerUtils {
       } catch (Throwable ignored) {
         // Region may already be invalid; ignore.
       }
+      // Terminate the in-flight download on the Dart side so its stream
+      // subscription is cleaned up and the awaiting Future resolves.
+      ad.channelHandler.onError(
+          "DatabaseReset",
+          "Offline database was reset before the download completed",
+          null);
     }
     activeDownloads.clear();
 
@@ -323,6 +329,12 @@ abstract class OfflineManagerUtils {
     if (active != null) {
       active.isComplete.set(true);
       active.region.setDownloadState(OfflineRegion.STATE_INACTIVE);
+      // Terminate the in-flight download on the Dart side so its stream
+      // subscription is cleaned up and the awaiting Future resolves.
+      active.channelHandler.onError(
+          "RegionDeleted",
+          "Region was deleted before the download completed",
+          null);
     }
     OfflineManager.Companion.getInstance(context)
         .listOfflineRegions(

--- a/maplibre_gl/example/pubspec.yaml
+++ b/maplibre_gl/example/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     path: ..
 
 dev_dependencies:
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.2.0
 
 dependency_overrides:
   maplibre_gl_platform_interface:

--- a/maplibre_gl/ios/maplibre_gl.podspec
+++ b/maplibre_gl/ios/maplibre_gl.podspec
@@ -16,7 +16,7 @@ MapLibre GL Flutter plugin.
   s.dependency 'Flutter'
   # When updating the dependency version,
   # make sure to also update the version in Package.swift.
-  s.dependency 'MapLibre', '6.24.0'
+  s.dependency 'MapLibre', '6.25.1'
   s.swift_version = '5.0'
   s.ios.deployment_target = '13.0'
 end

--- a/maplibre_gl/ios/maplibre_gl/Package.swift
+++ b/maplibre_gl/ios/maplibre_gl/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         // When updating the dependency version,
         // make sure to also update the version in maplibre_gl.podspec.
-        .package(url: "https://github.com/maplibre/maplibre-gl-native-distribution.git", exact: "6.24.0"),
+        .package(url: "https://github.com/maplibre/maplibre-gl-native-distribution.git", exact: "6.25.1"),
     ],
     targets: [
         .target(

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapsPlugin.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapsPlugin.swift
@@ -110,6 +110,41 @@ public class MapLibreMapsPlugin: NSObject, FlutterPlugin {
                     return
                 }
                 OfflineManagerUtils.deleteRegion(result: result, id: id)
+            case "clearAmbientCache":
+                OfflineManagerUtils.clearAmbientCache(result: result)
+            case "resetOfflineDatabase":
+                OfflineManagerUtils.resetOfflineDatabase(result: result)
+            case "pauseOfflineRegionDownload":
+                guard let args = methodCall.arguments as? [String: Any],
+                      let id = args["id"] as? Int
+                else {
+                    result(nil)
+                    return
+                }
+                OfflineManagerUtils.pauseRegion(result: result, id: id)
+            case "resumeOfflineRegionDownload":
+                guard let args = methodCall.arguments as? [String: Any],
+                      let id = args["id"] as? Int
+                else {
+                    result(nil)
+                    return
+                }
+                OfflineManagerUtils.resumeRegion(result: result, id: id)
+            case "getOfflineRegionStatus":
+                guard let args = methodCall.arguments as? [String: Any],
+                      let id = args["id"] as? Int
+                else {
+                    result(nil)
+                    return
+                }
+                OfflineManagerUtils.getRegionStatus(result: result, id: id)
+            case "setOfflineMaxConcurrentRequests":
+                let args = methodCall.arguments as? [String: Any]
+                let maxRequestsPerHost = args?["maxRequestsPerHost"] as? Int
+                OfflineManagerUtils.setMaxConcurrentRequests(
+                    result: result,
+                    maxRequestsPerHost: maxRequestsPerHost
+                )
             default:
                 result(FlutterMethodNotImplemented)
             }

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/OfflineChannelHandler.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/OfflineChannelHandler.swift
@@ -57,8 +57,19 @@ class OfflineChannelHandler: NSObject, FlutterStreamHandler {
         sink?(jsonString)
     }
 
-    func onProgress(progress: Double) {
-        let body: [String: Any] = ["status": "progress", "progress": progress]
+    func onProgress(
+        progress: Double,
+        completedResourceCount: UInt64 = 0,
+        requiredResourceCount: UInt64 = 0,
+        completedResourceSize: UInt64 = 0
+    ) {
+        let body: [String: Any] = [
+            "status": "progress",
+            "progress": progress,
+            "completedResourceCount": completedResourceCount,
+            "requiredResourceCount": requiredResourceCount,
+            "completedResourceSize": completedResourceSize,
+        ]
         guard let jsonData = try? JSONSerialization.data(
             withJSONObject: body,
             options: .prettyPrinted

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/OfflineManagerUtils.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/OfflineManagerUtils.swift
@@ -77,6 +77,13 @@ class OfflineManagerUtils {
         for (_, pack) in activePacks {
             pack.suspend()
         }
+        // Terminate the Dart-side subscriptions so their Futures resolve.
+        for (_, downloader) in activeDownloaders {
+            downloader.terminate(
+                errorCode: "DatabaseReset",
+                errorMessage: "Offline database was reset before the download completed"
+            )
+        }
         activePacks.removeAll()
         activeDownloaders.removeAll()
 
@@ -108,6 +115,12 @@ class OfflineManagerUtils {
         if let packToRemoveUnwrapped = packToRemove {
             // deletion is only safe if the download is suspended
             packToRemoveUnwrapped.suspend()
+            // Terminate the Dart-side subscription if a download is in flight.
+            activeDownloaders[id]?.terminate(
+                errorCode: "RegionDeleted",
+                errorMessage: "Region was deleted before the download completed"
+            )
+            activePacks.removeValue(forKey: id)
             OfflineManagerUtils.releaseDownloader(id: id)
 
             offlineStorage.removePack(packToRemoveUnwrapped) { error in

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/OfflineManagerUtils.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/OfflineManagerUtils.swift
@@ -11,6 +11,7 @@ import MapLibre
 
 class OfflineManagerUtils {
     static var activeDownloaders: [Int: OfflinePackDownloader] = [:]
+    static var activePacks: [Int: MLNOfflinePack] = [:]
 
     static func downloadRegion(
         definition: OfflineRegionDefinition,
@@ -57,6 +58,41 @@ class OfflineManagerUtils {
         result(nil)
     }
 
+    static func clearAmbientCache(result: @escaping FlutterResult) {
+        MLNOfflineStorage.shared.clearAmbientCache { error in
+            if let error = error {
+                result(FlutterError(
+                    code: "ClearAmbientCacheError",
+                    message: error.localizedDescription,
+                    details: nil
+                ))
+            } else {
+                result(nil)
+            }
+        }
+    }
+
+    static func resetOfflineDatabase(result: @escaping FlutterResult) {
+        // Any tracked in-progress downloads are invalidated by the reset.
+        for (_, pack) in activePacks {
+            pack.suspend()
+        }
+        activePacks.removeAll()
+        activeDownloaders.removeAll()
+
+        MLNOfflineStorage.shared.resetDatabase { error in
+            if let error = error {
+                result(FlutterError(
+                    code: "ResetDatabaseError",
+                    message: error.localizedDescription,
+                    details: nil
+                ))
+            } else {
+                result(nil)
+            }
+        }
+    }
+
     static func deleteRegion(result: @escaping FlutterResult, id: Int) {
         let offlineStorage = MLNOfflineStorage.shared
         guard let pacs = offlineStorage.packs else { return }
@@ -97,5 +133,99 @@ class OfflineManagerUtils {
     /// Removes downloader from cache so it's memory can be deallocated
     static func releaseDownloader(id: Int) {
         activeDownloaders.removeValue(forKey: id)
+    }
+
+    // MARK: Pause / Resume
+
+    static func pauseRegion(result: @escaping FlutterResult, id: Int) {
+        if let pack = findPack(id: id) {
+            pack.suspend()
+            result(nil)
+        } else {
+            result(FlutterError(
+                code: "PauseRegionError",
+                message: "There is no active region with given id to pause",
+                details: nil
+            ))
+        }
+    }
+
+    static func resumeRegion(result: @escaping FlutterResult, id: Int) {
+        if let pack = findPack(id: id) {
+            pack.resume()
+            result(nil)
+        } else {
+            result(FlutterError(
+                code: "ResumeRegionError",
+                message: "There is no active region with given id to resume",
+                details: nil
+            ))
+        }
+    }
+
+    // MARK: Region Status
+
+    static func getRegionStatus(result: @escaping FlutterResult, id: Int) {
+        if let pack = findPack(id: id) {
+            let progress = pack.progress
+            let completedCount = progress.countOfResourcesCompleted
+            let expectedCount = progress.countOfResourcesExpected
+            let downloadProgress = expectedCount > 0
+                ? 100.0 * Double(completedCount) / Double(expectedCount)
+                : 0.0
+
+            let statusDict: [String: Any] = [
+                "completedResourceCount": completedCount,
+                "requiredResourceCount": expectedCount,
+                "completedResourceSize": progress.countOfBytesCompleted,
+                "isComplete": pack.state == .complete,
+                "downloadProgress": downloadProgress,
+            ]
+
+            guard let jsonData = try? JSONSerialization.data(withJSONObject: statusDict),
+                  let jsonString = String(data: jsonData, encoding: .utf8)
+            else {
+                result(FlutterError(code: "GetRegionStatusError", message: "Failed to serialize status", details: nil))
+                return
+            }
+            result(jsonString)
+        } else {
+            result(FlutterError(
+                code: "GetRegionStatusError",
+                message: "There is no region with given id",
+                details: nil
+            ))
+        }
+    }
+
+    // MARK: Concurrency Control
+
+    static func setMaxConcurrentRequests(result: @escaping FlutterResult, maxRequestsPerHost: Int?) {
+        let sessionConfig = MLNNetworkConfiguration.sharedManager.sessionConfiguration ?? URLSessionConfiguration.default
+        if let maxPerHost = maxRequestsPerHost {
+            sessionConfig.httpMaximumConnectionsPerHost = maxPerHost
+        }
+        MLNNetworkConfiguration.sharedManager.sessionConfiguration = sessionConfig
+        result(nil)
+    }
+
+    // MARK: Pack Lookup
+
+    /// Finds a pack by region ID, checking active packs first then falling back to storage
+    private static func findPack(id: Int) -> MLNOfflinePack? {
+        // Check active packs first (in-progress downloads)
+        if let pack = activePacks[id] {
+            return pack
+        }
+        // Fall back to storage (completed/paused regions)
+        let offlineStorage = MLNOfflineStorage.shared
+        guard let packs = offlineStorage.packs else { return nil }
+        return packs.first { pack in
+            guard let contextJsonObject = try? JSONSerialization.jsonObject(with: pack.context),
+                  let contextJsonDict = contextJsonObject as? [String: Any],
+                  let regionId = contextJsonDict["id"] as? Int
+            else { return false }
+            return regionId == id
+        }
     }
 }

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/OfflinePackDownloadManager.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/OfflinePackDownloadManager.swift
@@ -74,6 +74,8 @@ class OfflinePackDownloader {
         {
             // Start downloading
             self.pack = pack
+            // Track pack for pause/resume support
+            OfflineManagerUtils.activePacks[region.id] = pack
             pack.resume()
             // Provide region with generated
             result(String(data: regionData, encoding: .utf8))
@@ -111,7 +113,6 @@ class OfflinePackDownloader {
         )
         // Check if downloading is complete
         if pack.state == .complete {
-            print("Region downloaded successfully")
             // set download state to inactive
             // This can be called multiple times but result can only be called once. We use this
             // check to ensure that
@@ -120,11 +121,16 @@ class OfflinePackDownloader {
             channelHandler.onSuccess()
             result(nil)
             if let region = OfflineRegion.fromOfflinePack(pack) {
+                OfflineManagerUtils.activePacks.removeValue(forKey: region.id)
                 OfflineManagerUtils.releaseDownloader(id: region.id)
             }
         } else {
-            print("Region download progress \(downloadProgress)")
-            channelHandler.onProgress(progress: downloadProgress)
+            channelHandler.onProgress(
+                progress: downloadProgress,
+                completedResourceCount: packProgress.countOfResourcesCompleted,
+                requiredResourceCount: packProgress.countOfResourcesExpected,
+                completedResourceSize: packProgress.countOfBytesCompleted
+            )
         }
     }
 
@@ -146,6 +152,7 @@ class OfflinePackDownloader {
             details: nil
         ))
         if let region = OfflineRegion.fromOfflinePack(pack) {
+            OfflineManagerUtils.activePacks.removeValue(forKey: region.id)
             OfflineManagerUtils.deleteRegion(result: result, id: region.id)
         }
     }
@@ -169,6 +176,7 @@ class OfflinePackDownloader {
             details: nil
         ))
         if let region = OfflineRegion.fromOfflinePack(pack) {
+            OfflineManagerUtils.activePacks.removeValue(forKey: region.id)
             OfflineManagerUtils.deleteRegion(result: result, id: region.id)
         }
     }

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/OfflinePackDownloadManager.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/OfflinePackDownloadManager.swift
@@ -47,6 +47,19 @@ class OfflinePackDownloader {
 
     // MARK: Public methods
 
+    /// Signals the awaiting Dart side that this download will not produce
+    /// further events. Used when the caller invalidates the download via
+    /// delete or reset before it can complete naturally.
+    func terminate(errorCode: String, errorMessage: String) {
+        guard !isCompleted else { return }
+        isCompleted = true
+        channelHandler.onError(
+            errorCode: errorCode,
+            errorMessage: errorMessage,
+            errorDetails: nil
+        )
+    }
+
     func download() -> Int {
         let storage = MLNOfflineStorage.shared
         // While the Android SDK generates a region ID in createOfflineRegion, the iOS

--- a/maplibre_gl/lib/src/download_region_status.dart
+++ b/maplibre_gl/lib/src/download_region_status.dart
@@ -6,12 +6,22 @@ class Success extends DownloadRegionStatus {}
 
 class InProgress extends DownloadRegionStatus {
   final double progress;
+  final int completedResourceCount;
+  final int requiredResourceCount;
+  final int completedResourceSize;
 
-  InProgress(this.progress);
+  InProgress(
+    this.progress, {
+    this.completedResourceCount = 0,
+    this.requiredResourceCount = 0,
+    this.completedResourceSize = 0,
+  });
 
   @override
   String toString() =>
-      "Instance of 'DownloadRegionStatus.InProgress', progress = $progress";
+      "Instance of 'DownloadRegionStatus.InProgress', progress = $progress, "
+      "completedResources = $completedResourceCount/$requiredResourceCount, "
+      "bytes = $completedResourceSize";
 }
 
 class Error extends DownloadRegionStatus {

--- a/maplibre_gl/lib/src/global.dart
+++ b/maplibre_gl/lib/src/global.dart
@@ -6,6 +6,14 @@ part of '../maplibre_gl.dart';
 
 const _globalChannel = MethodChannel('plugins.flutter.io/maplibre_gl');
 
+/// Retains active offline-download event-channel subscriptions so that Dart's
+/// GC cannot tear them down during idle periods (e.g. while a download is
+/// paused). If the subscription is collected, the native `EventSink` is
+/// released and subsequent progress/success events are silently dropped,
+/// causing the UI to appear stuck after resume.
+final Map<String, StreamSubscription<dynamic>> _offlineDownloadSubscriptions =
+    {};
+
 /// Copy tiles db file passed in to the tiles cache directory (sideloaded) to
 /// make tiles available offline.
 Future<void> installOfflineMapTiles(String tilesDb) async {
@@ -80,12 +88,68 @@ Future<dynamic> setOfflineTileCountLimit(int limit) =>
       },
     );
 
+/// Sets the maximum number of concurrent HTTP requests for tile downloads.
+///
+/// [maxRequests] controls the total number of concurrent requests (Android
+/// only). [maxRequestsPerHost] controls the per-host concurrency limit
+/// (both platforms). Lowering these values can help avoid rate limiting from
+/// tile servers (e.g. Cloudflare).
+Future<void> setOfflineMaxConcurrentRequests({
+  int? maxRequests,
+  int? maxRequestsPerHost,
+}) =>
+    _globalChannel.invokeMethod(
+      'setOfflineMaxConcurrentRequests',
+      <String, dynamic>{
+        if (maxRequests != null) 'maxRequests': maxRequests,
+        if (maxRequestsPerHost != null) 'maxRequestsPerHost': maxRequestsPerHost,
+      },
+    );
+
+/// Pauses an in-progress offline region download.
+Future<void> pauseOfflineRegionDownload(int id) =>
+    _globalChannel.invokeMethod(
+      'pauseOfflineRegionDownload',
+      <String, dynamic>{'id': id},
+    );
+
+/// Resumes a paused offline region download.
+Future<void> resumeOfflineRegionDownload(int id) =>
+    _globalChannel.invokeMethod(
+      'resumeOfflineRegionDownload',
+      <String, dynamic>{'id': id},
+    );
+
+/// Gets the current download status of an offline region.
+Future<OfflineRegionStatus> getOfflineRegionStatus(int id) async {
+  final String result = await _globalChannel.invokeMethod(
+    'getOfflineRegionStatus',
+    <String, dynamic>{'id': id},
+  );
+  return OfflineRegionStatus.fromMap(
+    Map<String, dynamic>.from(json.decode(result)),
+  );
+}
+
 Future<dynamic> deleteOfflineRegion(int id) => _globalChannel.invokeMethod(
   'deleteOfflineRegion',
   <String, dynamic>{
     'id': id,
   },
 );
+
+/// Removes all tiles from the shared ambient cache that are not associated
+/// with any offline region. Call this after [deleteOfflineRegion] to fully
+/// evict tiles that would otherwise be reused by a future download of the
+/// same area.
+Future<void> clearAmbientCache() =>
+    _globalChannel.invokeMethod('clearAmbientCache');
+
+/// Resets the entire offline database: deletes every offline region and
+/// clears the ambient cache. Use with care — offline regions cannot be
+/// recovered afterwards.
+Future<void> resetOfflineDatabase() =>
+    _globalChannel.invokeMethod('resetOfflineDatabase');
 
 Future<OfflineRegion> downloadOfflineRegion(
   OfflineRegionDefinition definition, {
@@ -103,11 +167,20 @@ Future<OfflineRegion> downloadOfflineRegion(
   );
 
   if (onEvent != null) {
-    EventChannel(channelName)
+    void cleanup() {
+      final sub = _offlineDownloadSubscriptions.remove(channelName);
+      if (sub != null) unawaited(sub.cancel());
+    }
+
+    // Subscription is retained in _offlineDownloadSubscriptions and cancelled
+    // in cleanup() on the terminal Success/Error event.
+    // ignore: cancel_subscriptions
+    final subscription = EventChannel(channelName)
         .receiveBroadcastStream()
         .handleError((error) {
           if (error is PlatformException) {
             onEvent(Error(error));
+            cleanup();
             return Error(error);
           }
           final unknownError = Error(
@@ -119,18 +192,30 @@ Future<OfflineRegion> downloadOfflineRegion(
             ),
           );
           onEvent(unknownError);
+          cleanup();
           return unknownError;
         })
         .listen((data) {
           final Map<String, Object?> jsonData = json.decode(data);
           final status = switch (jsonData['status']) {
             'start' => InProgress(0.0),
-            'progress' => InProgress((jsonData['progress']! as num).toDouble()),
+            'progress' => InProgress(
+                (jsonData['progress']! as num).toDouble(),
+                completedResourceCount:
+                    (jsonData['completedResourceCount'] as num?)?.toInt() ?? 0,
+                requiredResourceCount:
+                    (jsonData['requiredResourceCount'] as num?)?.toInt() ?? 0,
+                completedResourceSize:
+                    (jsonData['completedResourceSize'] as num?)?.toInt() ?? 0,
+              ),
             'success' => Success(),
             _ => throw Exception('Invalid event status ${jsonData['status']}'),
           };
           onEvent(status);
+          if (status is Success) cleanup();
         });
+
+    _offlineDownloadSubscriptions[channelName] = subscription;
   }
 
   final result = await _globalChannel.invokeMethod(

--- a/maplibre_gl/lib/src/global.dart
+++ b/maplibre_gl/lib/src/global.dart
@@ -148,8 +148,25 @@ Future<void> clearAmbientCache() =>
 /// Resets the entire offline database: deletes every offline region and
 /// clears the ambient cache. Use with care — offline regions cannot be
 /// recovered afterwards.
-Future<void> resetOfflineDatabase() =>
-    _globalChannel.invokeMethod('resetOfflineDatabase');
+Future<void> resetOfflineDatabase() async {
+  try {
+    await _globalChannel.invokeMethod('resetOfflineDatabase');
+  } finally {
+    // Belt-and-suspenders: in the normal path, native emits a terminal
+    // error for every in-flight download and cleanup() in the listener
+    // has already removed the entry from the map. The short delay gives
+    // any queued EventChannel messages a chance to be processed before we
+    // forcibly cancel anything that somehow slipped through, guaranteeing
+    // we don't leak retained subscriptions if the native terminal event
+    // is ever missed.
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    final stragglers = _offlineDownloadSubscriptions.values.toList();
+    _offlineDownloadSubscriptions.clear();
+    for (final sub in stragglers) {
+      unawaited(sub.cancel());
+    }
+  }
+}
 
 Future<OfflineRegion> downloadOfflineRegion(
   OfflineRegionDefinition definition, {

--- a/maplibre_gl/lib/src/global.dart
+++ b/maplibre_gl/lib/src/global.dart
@@ -97,28 +97,25 @@ Future<dynamic> setOfflineTileCountLimit(int limit) =>
 Future<void> setOfflineMaxConcurrentRequests({
   int? maxRequests,
   int? maxRequestsPerHost,
-}) =>
-    _globalChannel.invokeMethod(
-      'setOfflineMaxConcurrentRequests',
-      <String, dynamic>{
-        if (maxRequests != null) 'maxRequests': maxRequests,
-        if (maxRequestsPerHost != null) 'maxRequestsPerHost': maxRequestsPerHost,
-      },
-    );
+}) => _globalChannel.invokeMethod(
+  'setOfflineMaxConcurrentRequests',
+  <String, dynamic>{
+    if (maxRequests != null) 'maxRequests': maxRequests,
+    if (maxRequestsPerHost != null) 'maxRequestsPerHost': maxRequestsPerHost,
+  },
+);
 
 /// Pauses an in-progress offline region download.
-Future<void> pauseOfflineRegionDownload(int id) =>
-    _globalChannel.invokeMethod(
-      'pauseOfflineRegionDownload',
-      <String, dynamic>{'id': id},
-    );
+Future<void> pauseOfflineRegionDownload(int id) => _globalChannel.invokeMethod(
+  'pauseOfflineRegionDownload',
+  <String, dynamic>{'id': id},
+);
 
 /// Resumes a paused offline region download.
-Future<void> resumeOfflineRegionDownload(int id) =>
-    _globalChannel.invokeMethod(
-      'resumeOfflineRegionDownload',
-      <String, dynamic>{'id': id},
-    );
+Future<void> resumeOfflineRegionDownload(int id) => _globalChannel.invokeMethod(
+  'resumeOfflineRegionDownload',
+  <String, dynamic>{'id': id},
+);
 
 /// Gets the current download status of an offline region.
 Future<OfflineRegionStatus> getOfflineRegionStatus(int id) async {
@@ -217,14 +214,14 @@ Future<OfflineRegion> downloadOfflineRegion(
           final status = switch (jsonData['status']) {
             'start' => InProgress(0.0),
             'progress' => InProgress(
-                (jsonData['progress']! as num).toDouble(),
-                completedResourceCount:
-                    (jsonData['completedResourceCount'] as num?)?.toInt() ?? 0,
-                requiredResourceCount:
-                    (jsonData['requiredResourceCount'] as num?)?.toInt() ?? 0,
-                completedResourceSize:
-                    (jsonData['completedResourceSize'] as num?)?.toInt() ?? 0,
-              ),
+              (jsonData['progress']! as num).toDouble(),
+              completedResourceCount:
+                  (jsonData['completedResourceCount'] as num?)?.toInt() ?? 0,
+              requiredResourceCount:
+                  (jsonData['requiredResourceCount'] as num?)?.toInt() ?? 0,
+              completedResourceSize:
+                  (jsonData['completedResourceSize'] as num?)?.toInt() ?? 0,
+            ),
             'success' => Success(),
             _ => throw Exception('Invalid event status ${jsonData['status']}'),
           };

--- a/maplibre_gl/lib/src/offline_region.dart
+++ b/maplibre_gl/lib/src/offline_region.dart
@@ -74,3 +74,36 @@ class OfflineRegion {
   String toString() =>
       "OfflineRegion, id = $id, definition = $definition, metadata = $metadata";
 }
+
+/// Status of an offline region's download.
+class OfflineRegionStatus {
+  const OfflineRegionStatus({
+    required this.completedResourceCount,
+    required this.requiredResourceCount,
+    required this.completedResourceSize,
+    required this.isComplete,
+    required this.downloadProgress,
+  });
+
+  final int completedResourceCount;
+  final int requiredResourceCount;
+  final int completedResourceSize;
+  final bool isComplete;
+  final double downloadProgress;
+
+  factory OfflineRegionStatus.fromMap(Map<String, dynamic> json) {
+    return OfflineRegionStatus(
+      completedResourceCount: json['completedResourceCount'] as int,
+      requiredResourceCount: json['requiredResourceCount'] as int,
+      completedResourceSize: json['completedResourceSize'] as int,
+      isComplete: json['isComplete'] as bool,
+      downloadProgress: (json['downloadProgress'] as num).toDouble(),
+    );
+  }
+
+  @override
+  String toString() =>
+      "OfflineRegionStatus, progress = $downloadProgress, "
+      "complete = $isComplete, resources = $completedResourceCount/$requiredResourceCount, "
+      "bytes = $completedResourceSize";
+}

--- a/maplibre_gl/pubspec.yaml
+++ b/maplibre_gl/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.2.0
 
 flutter:
   plugin:

--- a/maplibre_gl/test/global_test.dart
+++ b/maplibre_gl/test/global_test.dart
@@ -156,6 +156,55 @@ void main() {
       expect(statuses[2], isA<Success>());
     });
 
+    test('onEvent receives progress with resource counts', () async {
+      final statuses = <DownloadRegionStatus>[];
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('plugins.flutter.io/maplibre_gl'),
+            (methodCall) async {
+              methodCalls.add(methodCall);
+
+              switch (methodCall.method) {
+                case 'downloadOfflineRegion#setup':
+                  capturedChannelName =
+                      (methodCall.arguments as Map)['channelName'] as String;
+
+                  _mockEventChannel(capturedChannelName!, [
+                    json.encode({
+                      'status': 'progress',
+                      'progress': 50.0,
+                      'completedResourceCount': 100,
+                      'requiredResourceCount': 200,
+                      'completedResourceSize': 1024000,
+                    }),
+                  ]);
+                  return null;
+                case 'downloadOfflineRegion':
+                  await Future<void>.delayed(const Duration(milliseconds: 50));
+                  return fakeRegionJson;
+                default:
+                  return null;
+              }
+            },
+          );
+
+      await downloadOfflineRegion(
+        definition,
+        onEvent: statuses.add,
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      expect(statuses, isNotEmpty);
+      expect(statuses[0], isA<InProgress>());
+      final progress = statuses[0] as InProgress;
+      expect(progress.progress, 50.0);
+      expect(progress.completedResourceCount, 100);
+      expect(progress.requiredResourceCount, 200);
+      expect(progress.completedResourceSize, 1024000);
+    });
+
     test('onEvent receives PlatformException as Error status', () async {
       final statuses = <DownloadRegionStatus>[];
 
@@ -198,6 +247,88 @@ void main() {
       expect(statuses, isNotEmpty);
       expect(statuses.first, isA<Error>());
       expect((statuses.first as Error).cause.code, 'DOWNLOAD_ERROR');
+    });
+  });
+
+  group('pauseOfflineRegionDownload', () {
+    test('sends correct method and arguments', () async {
+      await pauseOfflineRegionDownload(99);
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'pauseOfflineRegionDownload');
+      final args = methodCalls[0].arguments as Map;
+      expect(args['id'], 99);
+    });
+  });
+
+  group('resumeOfflineRegionDownload', () {
+    test('sends correct method and arguments', () async {
+      await resumeOfflineRegionDownload(99);
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'resumeOfflineRegionDownload');
+      final args = methodCalls[0].arguments as Map;
+      expect(args['id'], 99);
+    });
+  });
+
+  group('setOfflineMaxConcurrentRequests', () {
+    test('sends correct method and arguments with both params', () async {
+      await setOfflineMaxConcurrentRequests(
+        maxRequests: 32,
+        maxRequestsPerHost: 4,
+      );
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'setOfflineMaxConcurrentRequests');
+      final args = methodCalls[0].arguments as Map;
+      expect(args['maxRequests'], 32);
+      expect(args['maxRequestsPerHost'], 4);
+    });
+
+    test('sends only provided params', () async {
+      await setOfflineMaxConcurrentRequests(maxRequestsPerHost: 2);
+
+      expect(methodCalls.length, 1);
+      final args = methodCalls[0].arguments as Map;
+      expect(args.containsKey('maxRequests'), false);
+      expect(args['maxRequestsPerHost'], 2);
+    });
+  });
+
+  group('getOfflineRegionStatus', () {
+    test('returns parsed status', () async {
+      final fakeStatusJson = json.encode({
+        'completedResourceCount': 150,
+        'requiredResourceCount': 300,
+        'completedResourceSize': 2048000,
+        'isComplete': false,
+        'downloadProgress': 50.0,
+      });
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('plugins.flutter.io/maplibre_gl'),
+            (methodCall) async {
+              methodCalls.add(methodCall);
+              if (methodCall.method == 'getOfflineRegionStatus') {
+                return fakeStatusJson;
+              }
+              return null;
+            },
+          );
+
+      final status = await getOfflineRegionStatus(42);
+
+      expect(methodCalls.length, 1);
+      expect(methodCalls[0].method, 'getOfflineRegionStatus');
+      final args = methodCalls[0].arguments as Map;
+      expect(args['id'], 42);
+      expect(status.completedResourceCount, 150);
+      expect(status.requiredResourceCount, 300);
+      expect(status.completedResourceSize, 2048000);
+      expect(status.isComplete, false);
+      expect(status.downloadProgress, 50.0);
     });
   });
 }

--- a/maplibre_gl/test/offline_region_test.dart
+++ b/maplibre_gl/test/offline_region_test.dart
@@ -150,6 +150,26 @@ void main() {
       expect(status.progress, 0.5);
     });
 
+    test('InProgress stores resource counts', () {
+      final status = InProgress(
+        50.0,
+        completedResourceCount: 100,
+        requiredResourceCount: 200,
+        completedResourceSize: 1024000,
+      );
+      expect(status.progress, 50.0);
+      expect(status.completedResourceCount, 100);
+      expect(status.requiredResourceCount, 200);
+      expect(status.completedResourceSize, 1024000);
+    });
+
+    test('InProgress resource counts default to zero', () {
+      final status = InProgress(0.5);
+      expect(status.completedResourceCount, 0);
+      expect(status.requiredResourceCount, 0);
+      expect(status.completedResourceSize, 0);
+    });
+
     test('InProgress toString', () {
       final status = InProgress(0.75);
       expect(status.toString(), contains('0.75'));
@@ -166,6 +186,49 @@ void main() {
       final cause = PlatformException(code: 'ERROR', message: 'fail');
       final status = Error(cause);
       expect(status.toString(), contains('Error'));
+    });
+  });
+
+  group('OfflineRegionStatus', () {
+    test('fromMap constructs correctly', () {
+      final map = <String, dynamic>{
+        'completedResourceCount': 150,
+        'requiredResourceCount': 300,
+        'completedResourceSize': 2048000,
+        'isComplete': false,
+        'downloadProgress': 50.0,
+      };
+      final status = OfflineRegionStatus.fromMap(map);
+      expect(status.completedResourceCount, 150);
+      expect(status.requiredResourceCount, 300);
+      expect(status.completedResourceSize, 2048000);
+      expect(status.isComplete, false);
+      expect(status.downloadProgress, 50.0);
+    });
+
+    test('fromMap handles integer downloadProgress', () {
+      final map = <String, dynamic>{
+        'completedResourceCount': 100,
+        'requiredResourceCount': 100,
+        'completedResourceSize': 1024,
+        'isComplete': true,
+        'downloadProgress': 100,
+      };
+      final status = OfflineRegionStatus.fromMap(map);
+      expect(status.downloadProgress, 100.0);
+      expect(status.isComplete, true);
+    });
+
+    test('toString', () {
+      const status = OfflineRegionStatus(
+        completedResourceCount: 50,
+        requiredResourceCount: 100,
+        completedResourceSize: 512000,
+        isComplete: false,
+        downloadProgress: 50.0,
+      );
+      expect(status.toString(), contains('OfflineRegionStatus'));
+      expect(status.toString(), contains('50.0'));
     });
   });
 }

--- a/maplibre_gl/test/offline_region_test.dart
+++ b/maplibre_gl/test/offline_region_test.dart
@@ -225,10 +225,10 @@ void main() {
         requiredResourceCount: 100,
         completedResourceSize: 512000,
         isComplete: false,
-        downloadProgress: 50.0,
+        downloadProgress: 50.5,
       );
       expect(status.toString(), contains('OfflineRegionStatus'));
-      expect(status.toString(), contains('50.0'));
+      expect(status.toString(), contains('50.5'));
     });
   });
 }

--- a/maplibre_gl_example/android/app/src/main/AndroidManifest.xml
+++ b/maplibre_gl_example/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
-        android:label="maplibre_gl_example"
+        android:label="MapLibre Example"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/maplibre_gl_example/ios/Podfile.lock
+++ b/maplibre_gl_example/ios/Podfile.lock
@@ -4,10 +4,10 @@ PODS:
   - Flutter (1.0.0)
   - location (0.0.1):
     - Flutter
-  - MapLibre (6.24.0)
+  - MapLibre (6.25.1)
   - maplibre_gl (0.26.0):
     - Flutter
-    - MapLibre (= 6.24.0)
+    - MapLibre (= 6.25.1)
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -39,8 +39,8 @@ SPEC CHECKSUMS:
   device_info_plus: bf2e3232933866d73fe290f2942f2156cdd10342
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   location: d5cf8598915965547c3f36761ae9cc4f4e87d22e
-  MapLibre: 4b15619ecb1c5d63c2d32d3c51e7618fadcceb5f
-  maplibre_gl: 11c56a01bd47b13f1577b3dbfc8ddefe36f31255
+  MapLibre: 117b8f7f7956137697fc72f7485261f65d770091
+  maplibre_gl: 44719322523b9cc0b6888afdca7fc2ab8447087f
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
 
 PODFILE CHECKSUM: a57f30d18f102dd3ce366b1d62a55ecbef2158e5

--- a/maplibre_gl_example/lib/examples/advanced/offline_regions.dart
+++ b/maplibre_gl_example/lib/examples/advanced/offline_regions.dart
@@ -448,24 +448,23 @@ class _OfflineRegionsBodyState extends State<_OfflineRegionBody> {
       // Wait for the actual download to complete via EventChannel.
       await completer.future;
 
-      if (mounted) {
-        setState(() {
-          _items[index] = item.copyWith(
-            isDownloading: false,
-            downloadedId: downloadingRegion.id,
-          );
-        });
-      }
+      if (!mounted) return;
+      setState(() {
+        _items[index] = _items[index].copyWith(
+          isDownloading: false,
+          downloadedId: downloadingRegion.id,
+          isPaused: false,
+        );
+      });
     } on Exception catch (_) {
-      if (mounted) {
-        setState(() {
-          _items[index] = item.copyWith(
-            isDownloading: false,
-            downloadedId: null,
-          );
-        });
-      }
-      return;
+      if (!mounted) return;
+      setState(() {
+        _items[index] = _items[index].copyWith(
+          isDownloading: false,
+          downloadedId: null,
+          isPaused: false,
+        );
+      });
     }
   }
 

--- a/maplibre_gl_example/lib/examples/advanced/offline_regions.dart
+++ b/maplibre_gl_example/lib/examples/advanced/offline_regions.dart
@@ -14,8 +14,8 @@ final LatLngBounds hawaiiBounds = LatLngBounds(
 );
 
 final LatLngBounds santiagoBounds = LatLngBounds(
-  southwest: const LatLng(-33.5597, -70.49102),
-  northeast: const LatLng(-33.33282, -70.40102),
+  southwest: const LatLng(-33.65, -70.80),
+  northeast: const LatLng(-33.25, -70.40),
 );
 
 final LatLngBounds aucklandBounds = LatLngBounds(
@@ -51,25 +51,38 @@ class OfflineRegionListItem {
     required this.offlineRegionDefinition,
     required this.downloadedId,
     required this.isDownloading,
+    required this.isPaused,
     required this.name,
     required this.estimatedTiles,
+    this.downloadProgress = 0.0,
   });
 
   final OfflineRegionDefinition offlineRegionDefinition;
   final int? downloadedId;
   final bool isDownloading;
+  final bool isPaused;
   final String name;
   final int estimatedTiles;
+  final double downloadProgress;
+
+  static const _sentinel = Object();
 
   OfflineRegionListItem copyWith({
-    int? downloadedId,
+    Object? downloadedId = _sentinel,
     bool? isDownloading,
+    bool? isPaused,
+    double? downloadProgress,
   }) => OfflineRegionListItem(
     offlineRegionDefinition: offlineRegionDefinition,
     name: name,
     estimatedTiles: estimatedTiles,
-    downloadedId: downloadedId,
+    downloadedId:
+        identical(downloadedId, _sentinel)
+            ? this.downloadedId
+            : downloadedId as int?,
     isDownloading: isDownloading ?? this.isDownloading,
+    isPaused: isPaused ?? this.isPaused,
+    downloadProgress: downloadProgress ?? this.downloadProgress,
   );
 
   bool get isDownloaded => downloadedId != null;
@@ -80,6 +93,7 @@ final List<OfflineRegionListItem> allRegions = [
     offlineRegionDefinition: regionDefinitions[0],
     downloadedId: null,
     isDownloading: false,
+    isPaused: false,
     name: regionNames[0],
     estimatedTiles: 61,
   ),
@@ -87,13 +101,15 @@ final List<OfflineRegionListItem> allRegions = [
     offlineRegionDefinition: regionDefinitions[1],
     downloadedId: null,
     isDownloading: false,
+    isPaused: false,
     name: regionNames[1],
-    estimatedTiles: 3580,
+    estimatedTiles: 21000,
   ),
   OfflineRegionListItem(
     offlineRegionDefinition: regionDefinitions[2],
     downloadedId: null,
     isDownloading: false,
+    isPaused: false,
     name: regionNames[2],
     estimatedTiles: 202,
   ),
@@ -129,16 +145,51 @@ class _OfflineRegionsBodyState extends State<_OfflineRegionBody> {
 
   @override
   Widget build(BuildContext context) {
-    return _items.isEmpty
-        ? const Center(
-          child: CircularProgressIndicator(),
-        )
-        : ListView.builder(
-          padding: const EdgeInsets.all(16),
-          itemCount: _items.length,
-          itemBuilder: (context, index) {
-            final item = _items[index];
-            return Card(
+    if (_items.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+          child: Row(
+            children: [
+              Expanded(
+                child: ExampleButton(
+                  label: 'Clear Ambient Cache',
+                  icon: Icons.cleaning_services_outlined,
+                  onPressed: _handleClearAmbientCache,
+                  style: ExampleButtonStyle.outlined,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: ExampleButton(
+                  label: 'Reset Database',
+                  icon: Icons.delete_forever_outlined,
+                  onPressed: _handleResetDatabase,
+                  style: ExampleButtonStyle.destructive,
+                ),
+              ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: ListView.builder(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+            itemCount: _items.length,
+            itemBuilder: (context, index) {
+              final item = _items[index];
+              return _buildCard(item, index);
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCard(OfflineRegionListItem item, int index) {
+    return Card(
               margin: const EdgeInsets.only(bottom: 12),
               child: Column(
                 children: [
@@ -180,17 +231,35 @@ class _OfflineRegionsBodyState extends State<_OfflineRegionBody> {
                       ),
                     ),
                     subtitle: Text(
-                      'Estimated tiles: ${item.estimatedTiles}',
+                      item.isDownloading
+                          ? 'Progress: ${item.downloadProgress.toStringAsFixed(1)}%'
+                          : 'Estimated tiles: ${item.estimatedTiles}',
                       style: Theme.of(context).textTheme.bodyMedium,
                     ),
                     trailing:
                         item.isDownloading
-                            ? const SizedBox(
-                              width: 24,
-                              height: 24,
-                              child: CircularProgressIndicator(
-                                strokeWidth: 2,
-                              ),
+                            ? Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                IconButton(
+                                  icon: Icon(
+                                    item.isPaused
+                                        ? Icons.play_arrow
+                                        : Icons.pause,
+                                  ),
+                                  onPressed:
+                                      item.downloadedId != null
+                                          ? () => _togglePause(item, index)
+                                          : null,
+                                ),
+                                const SizedBox(
+                                  width: 24,
+                                  height: 24,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                  ),
+                                ),
+                              ],
                             )
                             : null,
                   ),
@@ -236,8 +305,85 @@ class _OfflineRegionsBodyState extends State<_OfflineRegionBody> {
                 ],
               ),
             );
-          },
-        );
+  }
+
+  Future<void> _handleClearAmbientCache() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Clear ambient cache?'),
+        content: const Text(
+          'Removes every cached tile that is not pinned to an offline '
+          'region, including tiles left behind by previously deleted '
+          'regions. Offline regions themselves are kept.\n\n'
+          'After this, re-downloading a region will fetch tiles from '
+          'the network instead of reusing the local cache.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Clear'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+
+    try {
+      await clearAmbientCache();
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Ambient cache cleared')),
+      );
+    } on Exception catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Clear ambient cache failed: $e')),
+      );
+    }
+  }
+
+  Future<void> _handleResetDatabase() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Reset offline database?'),
+        content: const Text(
+          'This will delete all offline regions and clear the ambient '
+          'cache. This cannot be undone.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Reset'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+
+    try {
+      await resetOfflineDatabase();
+      if (!mounted) return;
+      await _updateListOfRegions();
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Offline database reset')),
+      );
+    } on Exception catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Reset database failed: $e')),
+      );
+    }
   }
 
   Future<void> _updateListOfRegions() async {
@@ -261,9 +407,11 @@ class _OfflineRegionsBodyState extends State<_OfflineRegionBody> {
 
   Future<void> _downloadRegion(OfflineRegionListItem item, int index) async {
     setState(() {
-      _items.removeAt(index);
-      _items.insert(index, item.copyWith(isDownloading: true));
+      _items[index] = item.copyWith(isDownloading: true);
     });
+
+    // Use a Completer to wait for the Success/Error event from the EventChannel instead.
+    final completer = Completer<void>();
 
     try {
       final downloadingRegion = await downloadOfflineRegion(
@@ -271,50 +419,83 @@ class _OfflineRegionsBodyState extends State<_OfflineRegionBody> {
         metadata: {
           'name': regionNames[index],
         },
+        onEvent: (status) {
+          if (!mounted) return;
+          if (status is InProgress) {
+            setState(() {
+              _items[index] = _items[index].copyWith(
+                downloadProgress: status.progress,
+              );
+            });
+          } else if (status is Success && !completer.isCompleted) {
+            completer.complete();
+          } else if (status is Error && !completer.isCompleted) {
+            completer.completeError(status.cause);
+          }
+        },
       );
-      setState(() {
-        _items.removeAt(index);
-        _items.insert(
-          index,
-          item.copyWith(
+
+      // Region created — set the downloadedId so pause/resume can use it,
+      // but keep isDownloading: true until the Success event arrives.
+      if (mounted) {
+        setState(() {
+          _items[index] = _items[index].copyWith(
+            downloadedId: downloadingRegion.id,
+          );
+        });
+      }
+
+      // Wait for the actual download to complete via EventChannel.
+      await completer.future;
+
+      if (mounted) {
+        setState(() {
+          _items[index] = item.copyWith(
             isDownloading: false,
             downloadedId: downloadingRegion.id,
-          ),
-        );
-      });
+          );
+        });
+      }
     } on Exception catch (_) {
-      setState(() {
-        _items.removeAt(index);
-        _items.insert(
-          index,
-          item.copyWith(
+      if (mounted) {
+        setState(() {
+          _items[index] = item.copyWith(
             isDownloading: false,
             downloadedId: null,
-          ),
-        );
-      });
+          );
+        });
+      }
       return;
     }
   }
 
+  Future<void> _togglePause(OfflineRegionListItem item, int index) async {
+    final id = item.downloadedId;
+    if (id == null) return;
+    final shouldResume = item.isPaused;
+
+    try {
+      if (shouldResume) {
+        await resumeOfflineRegionDownload(id);
+      } else {
+        await pauseOfflineRegionDownload(id);
+      }
+      if (!mounted) return;
+      setState(() {
+        _items[index] = _items[index].copyWith(isPaused: !shouldResume);
+      });
+    } on Exception catch (_) {
+      // Download may have completed between UI update and button press
+    }
+  }
+
   Future<void> _deleteRegion(OfflineRegionListItem item, int index) async {
+    await deleteOfflineRegion(item.downloadedId!);
+    if (!mounted) return;
     setState(() {
-      _items.removeAt(index);
-      _items.insert(index, item.copyWith(isDownloading: true));
-    });
-
-    await deleteOfflineRegion(
-      item.downloadedId!,
-    );
-
-    setState(() {
-      _items.removeAt(index);
-      _items.insert(
-        index,
-        item.copyWith(
-          isDownloading: false,
-          downloadedId: null,
-        ),
+      _items[index] = _items[index].copyWith(
+        downloadedId: null,
+        isPaused: false,
       );
     });
   }

--- a/maplibre_gl_example/lib/examples/advanced/offline_regions.dart
+++ b/maplibre_gl_example/lib/examples/advanced/offline_regions.dart
@@ -190,146 +190,142 @@ class _OfflineRegionsBodyState extends State<_OfflineRegionBody> {
 
   Widget _buildCard(OfflineRegionListItem item, int index) {
     return Card(
-              margin: const EdgeInsets.only(bottom: 12),
-              child: Column(
-                children: [
-                  ListTile(
-                    contentPadding: const EdgeInsets.symmetric(
-                      horizontal: 16,
-                      vertical: 8,
-                    ),
-                    leading: Container(
-                      width: 48,
-                      height: 48,
-                      decoration: BoxDecoration(
-                        color:
-                            item.isDownloaded
-                                ? Theme.of(context).colorScheme.primaryContainer
-                                : Theme.of(
-                                  context,
-                                ).colorScheme.surfaceContainerHighest,
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      child: Icon(
-                        item.isDownloaded
-                            ? Icons.cloud_done
-                            : Icons.cloud_download,
-                        color:
-                            item.isDownloaded
-                                ? Theme.of(
-                                  context,
-                                ).colorScheme.onPrimaryContainer
-                                : Theme.of(
-                                  context,
-                                ).colorScheme.onSurfaceVariant,
-                      ),
-                    ),
-                    title: Text(
-                      item.name,
-                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                    subtitle: Text(
-                      item.isDownloading
-                          ? 'Progress: ${item.downloadProgress.toStringAsFixed(1)}%'
-                          : 'Estimated tiles: ${item.estimatedTiles}',
-                      style: Theme.of(context).textTheme.bodyMedium,
-                    ),
-                    trailing:
-                        item.isDownloading
-                            ? Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                IconButton(
-                                  icon: Icon(
-                                    item.isPaused
-                                        ? Icons.play_arrow
-                                        : Icons.pause,
-                                  ),
-                                  onPressed:
-                                      item.downloadedId != null
-                                          ? () => _togglePause(item, index)
-                                          : null,
-                                ),
-                                const SizedBox(
-                                  width: 24,
-                                  height: 24,
-                                  child: CircularProgressIndicator(
-                                    strokeWidth: 2,
-                                  ),
-                                ),
-                              ],
-                            )
-                            : null,
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.all(12),
-                    child: Row(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: Column(
+        children: [
+          ListTile(
+            contentPadding: const EdgeInsets.symmetric(
+              horizontal: 16,
+              vertical: 8,
+            ),
+            leading: Container(
+              width: 48,
+              height: 48,
+              decoration: BoxDecoration(
+                color:
+                    item.isDownloaded
+                        ? Theme.of(context).colorScheme.primaryContainer
+                        : Theme.of(
+                          context,
+                        ).colorScheme.surfaceContainerHighest,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Icon(
+                item.isDownloaded ? Icons.cloud_done : Icons.cloud_download,
+                color:
+                    item.isDownloaded
+                        ? Theme.of(
+                          context,
+                        ).colorScheme.onPrimaryContainer
+                        : Theme.of(
+                          context,
+                        ).colorScheme.onSurfaceVariant,
+              ),
+            ),
+            title: Text(
+              item.name,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            subtitle: Text(
+              item.isDownloading
+                  ? 'Progress: ${item.downloadProgress.toStringAsFixed(1)}%'
+                  : 'Estimated tiles: ${item.estimatedTiles}',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            trailing:
+                item.isDownloading
+                    ? Row(
+                      mainAxisSize: MainAxisSize.min,
                       children: [
-                        Expanded(
-                          child: ExampleButton(
-                            label: 'View Map',
-                            icon: Icons.map_outlined,
-                            onPressed: () => _goToMap(item),
-                            style: ExampleButtonStyle.outlined,
+                        IconButton(
+                          icon: Icon(
+                            item.isPaused ? Icons.play_arrow : Icons.pause,
+                          ),
+                          onPressed:
+                              item.downloadedId != null
+                                  ? () => _togglePause(item, index)
+                                  : null,
+                        ),
+                        const SizedBox(
+                          width: 24,
+                          height: 24,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
                           ),
                         ),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child:
-                              item.isDownloaded
-                                  ? ExampleButton(
-                                    label: 'Delete',
-                                    icon: Icons.delete_outline,
-                                    onPressed:
-                                        item.isDownloading
-                                            ? null
-                                            : () => _deleteRegion(item, index),
-                                    style: ExampleButtonStyle.destructive,
-                                  )
-                                  : ExampleButton(
-                                    label: 'Download',
-                                    icon: Icons.download,
-                                    onPressed:
-                                        item.isDownloading
-                                            ? null
-                                            : () =>
-                                                _downloadRegion(item, index),
-                                    style: ExampleButtonStyle.filled,
-                                  ),
-                        ),
                       ],
-                    ),
+                    )
+                    : null,
+          ),
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: Row(
+              children: [
+                Expanded(
+                  child: ExampleButton(
+                    label: 'View Map',
+                    icon: Icons.map_outlined,
+                    onPressed: () => _goToMap(item),
+                    style: ExampleButtonStyle.outlined,
                   ),
-                ],
-              ),
-            );
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child:
+                      item.isDownloaded
+                          ? ExampleButton(
+                            label: 'Delete',
+                            icon: Icons.delete_outline,
+                            onPressed:
+                                item.isDownloading
+                                    ? null
+                                    : () => _deleteRegion(item, index),
+                            style: ExampleButtonStyle.destructive,
+                          )
+                          : ExampleButton(
+                            label: 'Download',
+                            icon: Icons.download,
+                            onPressed:
+                                item.isDownloading
+                                    ? null
+                                    : () => _downloadRegion(item, index),
+                            style: ExampleButtonStyle.filled,
+                          ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
   }
 
   Future<void> _handleClearAmbientCache() async {
     final confirmed = await showDialog<bool>(
       context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Clear ambient cache?'),
-        content: const Text(
-          'Removes every cached tile that is not pinned to an offline '
-          'region, including tiles left behind by previously deleted '
-          'regions. Offline regions themselves are kept.\n\n'
-          'After this, re-downloading a region will fetch tiles from '
-          'the network instead of reusing the local cache.',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: const Text('Cancel'),
+      builder:
+          (ctx) => AlertDialog(
+            title: const Text('Clear ambient cache?'),
+            content: const Text(
+              'Removes every cached tile that is not pinned to an offline '
+              'region, including tiles left behind by previously deleted '
+              'regions. Offline regions themselves are kept.\n\n'
+              'After this, re-downloading a region will fetch tiles from '
+              'the network instead of reusing the local cache.',
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(ctx).pop(false),
+                child: const Text('Cancel'),
+              ),
+              FilledButton(
+                onPressed: () => Navigator.of(ctx).pop(true),
+                child: const Text('Clear'),
+              ),
+            ],
           ),
-          FilledButton(
-            onPressed: () => Navigator.of(ctx).pop(true),
-            child: const Text('Clear'),
-          ),
-        ],
-      ),
     );
     if (confirmed != true) return;
 
@@ -350,23 +346,24 @@ class _OfflineRegionsBodyState extends State<_OfflineRegionBody> {
   Future<void> _handleResetDatabase() async {
     final confirmed = await showDialog<bool>(
       context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Reset offline database?'),
-        content: const Text(
-          'This will delete all offline regions and clear the ambient '
-          'cache. This cannot be undone.',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: const Text('Cancel'),
+      builder:
+          (ctx) => AlertDialog(
+            title: const Text('Reset offline database?'),
+            content: const Text(
+              'This will delete all offline regions and clear the ambient '
+              'cache. This cannot be undone.',
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(ctx).pop(false),
+                child: const Text('Cancel'),
+              ),
+              FilledButton(
+                onPressed: () => Navigator.of(ctx).pop(true),
+                child: const Text('Reset'),
+              ),
+            ],
           ),
-          FilledButton(
-            onPressed: () => Navigator.of(ctx).pop(true),
-            child: const Text('Reset'),
-          ),
-        ],
-      ),
     );
     if (confirmed != true) return;
 

--- a/maplibre_gl_example/pubspec.yaml
+++ b/maplibre_gl_example/pubspec.yaml
@@ -11,12 +11,12 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  collection: ^1.17.1
-  device_info_plus: ^12.1.0
+  collection: ^1.19.1
+  device_info_plus: ^13.1.0
   flutter:
     sdk: flutter
   flutter_hooks: ^0.21.3+1
-  http: ^1.1.0
+  http: ^1.6.0
   location: ^8.0.1
   maplibre_gl:
     path: ../maplibre_gl
@@ -25,7 +25,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.2.0
 
 flutter:
   uses-material-design: true

--- a/maplibre_gl_example/pubspec.yaml
+++ b/maplibre_gl_example/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   collection: ^1.19.1
-  device_info_plus: ^13.1.0
+  device_info_plus: ^12.3.0
   flutter:
     sdk: flutter
   flutter_hooks: ^0.21.3+1

--- a/maplibre_gl_example/pubspec.yaml
+++ b/maplibre_gl_example/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   collection: ^1.19.1
-  device_info_plus: ^12.3.0
+  device_info_plus: 12.3.0
   flutter:
     sdk: flutter
   flutter_hooks: ^0.21.3+1

--- a/maplibre_gl_example/web/index.html
+++ b/maplibre_gl_example/web/index.html
@@ -30,8 +30,8 @@
   <link rel="icon" type="image/png" href="favicon.png"/>
 
   <!-- MapLibre -->
-  <script src='https://unpkg.com/maplibre-gl@^5.21.0/dist/maplibre-gl.js'></script>
-  <link href='https://unpkg.com/maplibre-gl@^5.21.0/dist/maplibre-gl.css' rel='stylesheet'/>
+  <script src='https://unpkg.com/maplibre-gl@^5.24.0/dist/maplibre-gl.js'></script>
+  <link href='https://unpkg.com/maplibre-gl@^5.24.0/dist/maplibre-gl.css' rel='stylesheet'/>
   <script src="https://unpkg.com/pmtiles@4.4.0/dist/pmtiles.js"></script>
 
   <title>MapLibre Example</title>

--- a/maplibre_gl_platform_interface/pubspec.yaml
+++ b/maplibre_gl_platform_interface/pubspec.yaml
@@ -12,9 +12,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.0.5
+  meta: ^1.17.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.2.0

--- a/maplibre_gl_web/pubspec.yaml
+++ b/maplibre_gl_web/pubspec.yaml
@@ -21,13 +21,13 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  image: ^4.0.17
+  image: ^4.8.0
   maplibre_gl_platform_interface: ^0.26.0
-  meta: ^1.3.0
+  meta: ^1.17.0
   web: ^1.1.1
 
 dev_dependencies:
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.2.0
 
 platforms:
   web:

--- a/scripts/pubspec.yaml
+++ b/scripts/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   sdk: ">=3.7.0 <4.0.0"
 
 dependencies:
-  mustache_template: ^2.0.1
+  mustache_template: ^2.0.4
   recase: ^4.1.0
 
 dev_dependencies:
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.2.0


### PR DESCRIPTION
## Summary

Adds richer control and observability over offline region downloads on both Android and iOS.

### New APIs
- `pauseOfflineRegionDownload` / `resumeOfflineRegionDownload` — control in-progress downloads.
- `getOfflineRegionStatus` → `OfflineRegionStatus` — resource counts, bytes, progress, completion.
- `clearAmbientCache` / `resetOfflineDatabase` — evict unpinned tiles or fully reset the offline DB.
- `setOfflineMaxConcurrentRequests` — cap tile concurrency (total on Android, per-host on both) to avoid upstream rate limiting.
- `InProgress` events now carry `completedResourceCount`, `requiredResourceCount`, and `completedResourceSize`.

### Fixes
- Retain offline download `StreamSubscription`s so Dart GC cannot drop native events while a download is paused.
- Android: throttle progress events (100ms) and discard non-monotonic counts so cache-served bursts don't starve the isolate and block pause taps.
- Android/iOS: track in-flight downloads so pause/resume/status operate on the live region/pack.

### Example
- Offline regions screen gains a pause toggle, live progress %, and buttons for clear-cache / reset-DB.
