### PR TITLE
Android: Survive "Don't keep activities" and config changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## Unreleased
+
+### Added
+* `pauseMap()` and `resumeMap()` on `MapLibreMapController` to explicitly pause and resume map rendering. Useful for maps that are not visible (e.g. on an inactive `TabBarView` page) to save GPU/CPU. The paused state survives host-activity backgrounding (#805).
+  * **Android**: stops the underlying MapView render loop.
+  * **iOS**: no-op (the OS already halts rendering for off-screen views).
+  * **Web**: no-op.
+
+### Fixed
+* **Android**: Maps no longer go permanently blank after the host activity is destroyed and recreated by Android's "Don't keep activities" developer option or by aggressive memory pressure. The MapView is now rebuilt against the fresh activity and camera state is restored automatically (#805).
+* **Android**: Maps survive configuration changes such as device rotation, restoring camera state across the activity recreation (#805).
+
+### Note for app developers
+On Android the `MapView` is rebuilt across activity recreation. Camera is restored automatically. Runtime-added sources/layers/images and style switches must be applied inside `onStyleLoadedCallback` (the recommended pattern, also documented on `MapLibreMap.onMapCreated`): the callback fires again on each recreation, so apps that already follow it see their style content re-applied automatically. 
+
+Apps adding style content in `onMapCreated` or `initState` will need to move that code into `onStyleLoadedCallback`.
+
 ## [0.26.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.25.0...v0.26.0)
 
 #### Version 0.26.0 marks a milestone for `flutter-maplibre-gl`

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -1,3 +1,18 @@
+See top-level [CHANGELOG.md](../CHANGELOG.md) for full details.
+
+## Unreleased
+
+### Added
+* `pauseMap()` / `resumeMap()` on `MapLibreMapController`. Android stops the MapView render loop; iOS and web are no-op (#805).
+
+### Fixed
+* **Android**: Maps survive host activity destruction (e.g. "Don't keep activities", memory pressure) and configuration changes (e.g. rotation). The MapView is rebuilt against the fresh activity context with camera position restored automatically (#805).
+
+### Note for app developers
+On Android the `MapView` is rebuilt across activity recreation. Camera is restored automatically. Runtime-added sources/layers/images and style switches must be applied inside `onStyleLoadedCallback` (the recommended pattern, also documented on `MapLibreMap.onMapCreated`): the callback fires again on each recreation, so apps that already follow it see their style content re-applied automatically. 
+
+Apps adding style content in `onMapCreated` or `initState` will need to move that code into `onStyleLoadedCallback`.
+
 ## [0.26.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.25.0...v0.26.0)
 
 **Version 0.26.0 is a milestone release for flutter-maplibre-gl.** \

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
@@ -126,7 +126,11 @@ final class MapLibreMapController
   private final int id;
   private final MethodChannel methodChannel;
   private final MapLibreMapsPlugin.LifecycleProvider lifecycleProvider;
+  private final MapLibreMapOptions mapLibreMapOptions;
+  private Lifecycle boundLifecycle;
+  private CameraPosition lastCameraPosition;
   private float density;
+  private final Context applicationContext;
   private final Context context;
   private final String styleStringInitial;
   /**
@@ -198,10 +202,13 @@ final class MapLibreMapController
     MapLibreUtils.getMapLibre(context);
     this.id = id;
     this.context = context;
+    this.applicationContext =
+        context.getApplicationContext() != null ? context.getApplicationContext() : context;
+    this.mapLibreMapOptions = options;
     this.dragEnabled = dragEnabled;
     this.featureTapsTriggersMapClick = featureTapsTriggersMapClick;
     this.styleStringInitial = styleStringInitial;
-    this.mapViewContainer = new FrameLayout(context);
+    this.mapViewContainer = new FrameLayout(applicationContext);
     this.mapView = new MapView(context, options);
     this.interactiveFeatureLayerIds = new HashSet<>();
     this.addedFeaturesByLayer = new HashMap<String, FeatureCollection>();
@@ -222,8 +229,88 @@ final class MapLibreMapController
   }
 
   void init() {
-    lifecycleProvider.getLifecycle().addObserver(this);
-    context.registerComponentCallbacks(this);
+    registerToLifecycle();
+    applicationContext.registerComponentCallbacks(this);
+    mapView.getMapAsync(this);
+  }
+
+  void onActivityAttached() {
+    if (disposed) {
+      return;
+    }
+
+    unregisterFromLifecycle();
+
+    if (mapView == null) {
+      recreateMapViewIfNecessary();
+    }
+
+    registerToLifecycle();
+  }
+
+  void onActivityDetached() {
+    saveCameraPosition();
+    destroyMapViewIfNecessary();
+    unregisterFromLifecycle();
+  }
+
+  /**
+   * Rebind after config change (e.g. rotation). The old lifecycle's onDestroy may have
+   * already destroyed the map view, so recreate if necessary.
+   */
+  void onActivityRebound() {
+    if (disposed) {
+      return;
+    }
+    unregisterFromLifecycle();
+    if (mapView == null) {
+      recreateMapViewIfNecessary();
+    }
+    registerToLifecycle();
+  }
+
+  private void registerToLifecycle() {
+    Lifecycle lifecycle = lifecycleProvider.getLifecycle();
+    if (lifecycle != null && lifecycle != boundLifecycle) {
+      lifecycle.addObserver(this);
+      boundLifecycle = lifecycle;
+    }
+  }
+
+  private void unregisterFromLifecycle() {
+    if (boundLifecycle != null) {
+      boundLifecycle.removeObserver(this);
+      boundLifecycle = null;
+    }
+  }
+
+  private void saveCameraPosition() {
+    if (mapLibreMap != null) {
+      lastCameraPosition = mapLibreMap.getCameraPosition();
+    }
+  }
+
+  private void recreateMapViewIfNecessary() {
+    if (mapView != null) {
+      return;
+    }
+
+    final Context activityContext = lifecycleProvider.getContext();
+    final Context mapContext = activityContext != null ? activityContext : context;
+
+    mapLibreMap = null;
+    style = null;
+    locationComponent = null;
+    mapViewStarted = false;
+    interactiveFeatureLayerIds.clear();
+    addedFeaturesByLayer.clear();
+
+    mapViewContainer.removeAllViews();
+    mapView = new MapView(mapContext, mapLibreMapOptions);
+    if (dragEnabled) {
+      androidGesturesManager = new AndroidGesturesManager(mapView.getContext(), false);
+    }
+    mapViewContainer.addView(mapView);
     mapView.getMapAsync(this);
   }
 
@@ -236,7 +323,10 @@ final class MapLibreMapController
   }
 
   private CameraPosition getCameraPosition() {
-    return trackCameraPosition ? mapLibreMap.getCameraPosition() : null;
+    if (!trackCameraPosition || mapLibreMap == null) {
+      return null;
+    }
+    return mapLibreMap.getCameraPosition();
   }
 
   @Override
@@ -253,6 +343,12 @@ final class MapLibreMapController
     // Apply camera target bounds if set during initialization
     if (bounds != null) {
       mapLibreMap.setLatLngBoundsForCameraTarget(bounds);
+    }
+
+    // Restore camera position after map recreation (e.g. "Don't keep activities")
+    if (lastCameraPosition != null) {
+      mapLibreMap.moveCamera(CameraUpdateFactory.newCameraPosition(lastCameraPosition));
+      lastCameraPosition = null;
     }
 
     if (androidGesturesManager != null) {
@@ -844,6 +940,21 @@ final class MapLibreMapController
           result.success(Convert.toJson(getCameraPosition()));
           break;
         }
+      // All cases below require a live mapLibreMap. If the map is being recreated
+      // (e.g. after "Don't keep activities") we stash the result so the Flutter
+      // side gets its answer once onMapReady fires again.
+      default:
+        if (mapLibreMap == null) {
+          result.error("MAP_NOT_READY", "Map is not ready (activity may have been recreated)", null);
+          return;
+        }
+        onMethodCallWithMap(call, result);
+        return;
+    }
+  }
+
+  private void onMethodCallWithMap(MethodCall call, MethodChannel.Result result) {
+    switch (call.method) {
       case "map#updateMyLocationTrackingMode":
         {
           int myLocationTrackingMode = call.argument("mode");
@@ -2164,13 +2275,10 @@ final class MapLibreMapController
       mapViewStarted = false;
     }
     destroyMapViewIfNecessary();
-    Lifecycle lifecycle = lifecycleProvider.getLifecycle();
-    if (lifecycle != null) {
-      lifecycle.removeObserver(this);
-    }
+    unregisterFromLifecycle();
 
     try {
-      context.unregisterComponentCallbacks(this);
+      applicationContext.unregisterComponentCallbacks(this);
     } catch (Exception e) {
       // Ignore if already unregistered
     }
@@ -2257,6 +2365,10 @@ final class MapLibreMapController
     mapView.onStop();
     mapView.onDestroy();
 
+    mapViewStarted = false;
+    mapLibreMap = null;
+    style = null;
+    locationComponent = null;
     mapView = null;
   }
 
@@ -2288,12 +2400,13 @@ final class MapLibreMapController
     if (myLocationEnabled) {
       startListeningForLocationUpdates();
     }
-    // Force a repaint to fix invisible map when returning from background
-    // Use standard Android view invalidation to trigger a repaint
-    mapView.post(new Runnable() {
+    // Force a repaint to fix invisible map when returning from background.
+    // Capture a local reference so the Runnable is safe if mapView is nulled before execution.
+    final MapView mv = mapView;
+    mv.post(new Runnable() {
       @Override
       public void run() {
-        mapView.invalidate();
+        mv.invalidate();
       }
     });
   }
@@ -2319,10 +2432,16 @@ final class MapLibreMapController
 
   @Override
   public void onDestroy(@NonNull LifecycleOwner owner) {
-    owner.getLifecycle().removeObserver(this);
+    if (owner.getLifecycle() != boundLifecycle) {
+      // Stale callback from an old activity (e.g. after config change where we already
+      // rebound to the new lifecycle). Ignore — destroying now would kill the live map.
+      return;
+    }
+    unregisterFromLifecycle();
     if (disposed) {
       return;
     }
+    saveCameraPosition();
     destroyMapViewIfNecessary();
   }
 

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
@@ -149,6 +149,7 @@ final class MapLibreMapController
   private boolean dragEnabled = true;
   private boolean featureTapsTriggersMapClick = false;
   private boolean mapViewStarted = false;
+  private boolean userPaused = false;
   private MethodChannel.Result mapReadyResult;
   private LocationComponent locationComponent = null;
   private LocationEngineCallback<LocationEngineResult> locationEngineCallback = null;
@@ -298,10 +299,13 @@ final class MapLibreMapController
     final Context activityContext = lifecycleProvider.getContext();
     final Context mapContext = activityContext != null ? activityContext : context;
 
+    final boolean wasPaused = userPaused;
+
     mapLibreMap = null;
     style = null;
     locationComponent = null;
     mapViewStarted = false;
+    userPaused = wasPaused;
     interactiveFeatureLayerIds.clear();
     addedFeaturesByLayer.clear();
 
@@ -940,6 +944,20 @@ final class MapLibreMapController
           result.success(Convert.toJson(getCameraPosition()));
           break;
         }
+      case "map#pause":
+        userPaused = true;
+        if (mapView != null && !disposed) {
+          mapView.onPause();
+        }
+        result.success(null);
+        break;
+      case "map#resume":
+        userPaused = false;
+        if (mapView != null && !disposed) {
+          mapView.onResume();
+        }
+        result.success(null);
+        break;
       // All cases below require a live mapLibreMap. If the map is being recreated
       // (e.g. after "Don't keep activities") we stash the result so the Flutter
       // side gets its answer once onMapReady fires again.
@@ -2394,6 +2412,9 @@ final class MapLibreMapController
   @Override
   public void onResume(@NonNull LifecycleOwner owner) {
     if (disposed || mapView == null) {
+      return;
+    }
+    if (userPaused) {
       return;
     }
     mapView.onResume();

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
@@ -9,6 +9,7 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.content.res.AssetFileDescriptor;
+import android.os.Bundle;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.PointF;
@@ -106,7 +107,56 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.platform.PlatformView;
 
 
-/** Controller of a single MapLibreMaps MapView instance. */
+/**
+ * Controller of a single MapLibre {@link MapView} instance exposed as a Flutter
+ * {@link PlatformView}. Mediates between the Flutter method channel, the host
+ * activity {@link Lifecycle}, and the native {@link MapView}.
+ *
+ * <h2>Surviving activity recreation</h2>
+ * Android can destroy and recreate the host activity at any time (rotation,
+ * "Don't keep activities", memory pressure). Because the {@link MapView} holds
+ * GL resources tied to its constructing activity context, it must be destroyed
+ * alongside the activity and rebuilt against the new one. This controller
+ * handles that automatically so the Flutter widget tree never sees the swap.
+ *
+ * <h3>State bridge</h3>
+ * <ul>
+ *   <li>{@link #lastCameraPosition} — explicit camera snapshot, restored in
+ *       {@link #onMapReady}.</li>
+ *   <li>{@link #savedMapViewState} — opaque MapLibre bundle written via
+ *       {@link MapView#onSaveInstanceState(Bundle)} and replayed into
+ *       {@link MapView#onCreate(Bundle)} on the new instance.</li>
+ *   <li>Controller fields (e.g. {@link #myLocationEnabled},
+ *       {@link #trackCameraPosition}, {@link #bounds}) — live on the controller
+ *       which itself outlives the activity.</li>
+ * </ul>
+ *
+ * <h3>State NOT preserved</h3>
+ * Sources, layers, images, runtime style switches, runtime UI tweaks via
+ * {@code map#update}, and in-flight gestures are all lost. Dart code is
+ * expected to re-apply them when {@code map#onStyleLoaded} fires for the new
+ * MapView. See {@link #recreateMapViewIfNecessary()} for the full breakdown.
+ *
+ * <h3>Lifecycle plumbing</h3>
+ * Three hooks ({@link #onActivityAttached()}, {@link #onActivityDetached()},
+ * {@link #onActivityRebound()}) are broadcast from {@link MapLibreMapFactory}
+ * in response to Flutter's {@code ActivityAware} callbacks. Combined with the
+ * idempotent {@code mapViewCreated/Started/Resumed} flags they ensure each
+ * {@link MapView} instance sees a balanced sequence of {@code onCreate} →
+ * {@code onStart} → {@code onResume} → {@code onPause} → {@code onStop} →
+ * {@code onDestroy} regardless of how Jetpack replays lifecycle events.
+ *
+ * <h3>Method channel during recreation</h3>
+ * While the {@link MapView} is being rebuilt the controller may receive method
+ * calls from Dart. {@code map#waitForMap} parks the result and replies once
+ * {@link #onMapReady} fires again; every other map-touching call returns
+ * {@code MAP_NOT_READY} so Dart can decide whether to retry.
+ *
+ * <h3>Dart-driven pause</h3>
+ * {@code map#pause} / {@code map#resume} expose explicit rendering control via
+ * {@link #userPaused}. When set, the natural lifecycle {@code onResume} is
+ * suppressed so a paused map stays paused across backgrounding.
+ */
 @SuppressLint("MissingPermission")
 final class MapLibreMapController
     implements DefaultLifecycleObserver,
@@ -127,14 +177,41 @@ final class MapLibreMapController
   private final MethodChannel methodChannel;
   private final MapLibreMapsPlugin.LifecycleProvider lifecycleProvider;
   private final MapLibreMapOptions mapLibreMapOptions;
+  /**
+   * The {@link Lifecycle} this controller is currently observing. Used to detect
+   * stale callbacks from a destroyed activity and to avoid double-subscription
+   * when the host activity is recreated (e.g. "Don't keep activities", rotation).
+   */
   private Lifecycle boundLifecycle;
+  /**
+   * Last known camera position. Saved before destroying the {@link MapView} so it
+   * can be restored once the map is recreated in a fresh activity. Cleared after
+   * being applied in {@link #onMapReady(MapLibreMap)}.
+   */
   private CameraPosition lastCameraPosition;
+  /**
+   * State bundle written by {@link MapView#onSaveInstanceState(Bundle)} before the
+   * {@link MapView} is destroyed and read back by {@link MapView#onCreate(Bundle)}
+   * on the recreated instance. Lets MapLibre restore internal state (camera, style
+   * progress, etc.) across activity recreation, complementing {@link #lastCameraPosition}.
+   */
+  private final Bundle savedMapViewState = new Bundle();
   private float density;
   private final Context applicationContext;
-  private final Context context;
+  /**
+   * Activity context used to build the {@link MapView}. Re-pointed at the current
+   * activity on every {@link #onActivityAttached()}/{@link #onActivityRebound()} so
+   * we don't pin a destroyed activity in memory. Do NOT register long-lived listeners
+   * against this field directly — for component callbacks and similar, prefer
+   * {@link #applicationContext}.
+   */
+  private Context context;
   private final String styleStringInitial;
   /**
-   * This container is returned as the final platform view instead of returning `mapView`.
+   * Container that wraps the {@link MapView}. Returned as the platform view so the
+   * inner {@link MapView} can be swapped out (after activity recreation) without
+   * Flutter noticing. Created with {@link #applicationContext} on purpose: it lives
+   * across activities, and uses no activity-themed attributes.
    * See {@link MapLibreMapController#destroyMapViewIfNecessary()} for details.
    */
   private FrameLayout mapViewContainer;
@@ -148,7 +225,22 @@ final class MapLibreMapController
   private boolean disposed = false;
   private boolean dragEnabled = true;
   private boolean featureTapsTriggersMapClick = false;
+  /**
+   * Idempotency guards for {@link MapView} lifecycle dispatch. Jetpack's
+   * {@code Lifecycle.addObserver} replays missed events synchronously, which would
+   * otherwise re-invoke {@code mapView.onCreate/onStart/onResume} on an already
+   * initialized {@link MapView}. These flags ensure each transition fires once
+   * per {@link MapView} instance.
+   */
+  private boolean mapViewCreated = false;
   private boolean mapViewStarted = false;
+  private boolean mapViewResumed = false;
+  /**
+   * True when Dart has explicitly requested {@code pauseMap()}. Suppresses the
+   * natural {@link #onResume(LifecycleOwner)} until {@code resumeMap()} is called,
+   * so a backgrounded map stays paused even when the host activity returns to the
+   * foreground.
+   */
   private boolean userPaused = false;
   private MethodChannel.Result mapReadyResult;
   private LocationComponent locationComponent = null;
@@ -229,26 +321,62 @@ final class MapLibreMapController
     return mapViewContainer;
   }
 
+  /**
+   * Initial wire-up after construction. Order matters:
+   * <ol>
+   *   <li>Register component callbacks against the {@link #applicationContext}
+   *       so we don't pin the host {@link android.app.Activity}.</li>
+   *   <li>Subscribe to the host activity {@link Lifecycle}. Jetpack replays the
+   *       missed events synchronously, which drives {@code mapView.onCreate()},
+   *       {@code onStart()} and {@code onResume()} via our lifecycle observer
+   *       methods. The {@link #savedMapViewState} bundle is empty here, which
+   *       is equivalent to "no saved state" for MapLibre.</li>
+   *   <li>Call {@link MapView#getMapAsync} only AFTER {@code onCreate} has fired,
+   *       to comply with MapLibre's documented call order.</li>
+   * </ol>
+   */
   void init() {
-    registerToLifecycle();
     applicationContext.registerComponentCallbacks(this);
+    registerToLifecycle();
     mapView.getMapAsync(this);
   }
 
+  /**
+   * Invoked by {@link MapLibreMapFactory} when the plugin re-attaches to an activity.
+   * Triggered both on first attach and after a full activity teardown (e.g. with
+   * "Don't keep activities" enabled). Refreshes context references, recreates the
+   * {@link MapView} if the previous one was destroyed, and rebinds the new lifecycle.
+   */
   void onActivityAttached() {
     if (disposed) {
       return;
     }
 
     unregisterFromLifecycle();
+    updateActivityContext();
 
-    if (mapView == null) {
+    final boolean recreated = (mapView == null);
+    if (recreated) {
       recreateMapViewIfNecessary();
     }
 
+    // Register the new lifecycle BEFORE getMapAsync so Jetpack's synchronous
+    // replay drives mapView.onCreate(savedMapViewState) first. Calling
+    // getMapAsync against a not-yet-created MapView is technically tolerated
+    // by MapLibre but violates the documented contract.
     registerToLifecycle();
+
+    if (recreated) {
+      mapView.getMapAsync(this);
+    }
   }
 
+  /**
+   * Invoked when the plugin is fully detached from the activity (i.e. the host
+   * activity is being destroyed without a config change — e.g. "Don't keep
+   * activities" or a real activity finish). Saves what state we can and tears
+   * down the native {@link MapView}.
+   */
   void onActivityDetached() {
     saveCameraPosition();
     destroyMapViewIfNecessary();
@@ -256,18 +384,42 @@ final class MapLibreMapController
   }
 
   /**
-   * Rebind after config change (e.g. rotation). The old lifecycle's onDestroy may have
-   * already destroyed the map view, so recreate if necessary.
+   * Invoked after a configuration change (e.g. rotation). In the Flutter standard
+   * ordering the old activity's {@code onDestroy} fires before this hook, so by
+   * the time we get here the {@link MapView} has already been torn down via the
+   * lifecycle observer and we go through the same path as a full re-attach. The
+   * fast-path (mapView still alive) only triggers if reattachment somehow beats
+   * the old activity's destroy callback. {@link #lastCameraPosition} and
+   * {@link #savedMapViewState} bridge the gap either way.
    */
   void onActivityRebound() {
     if (disposed) {
       return;
     }
     unregisterFromLifecycle();
-    if (mapView == null) {
+    updateActivityContext();
+
+    final boolean recreated = (mapView == null);
+    if (recreated) {
       recreateMapViewIfNecessary();
     }
     registerToLifecycle();
+    if (recreated) {
+      mapView.getMapAsync(this);
+    }
+  }
+
+  /**
+   * Re-points {@link #context} at the freshly attached activity so we never hold a
+   * destroyed activity reference. Also refreshes {@link #density} because display
+   * configuration can change across activity recreation (font scale, display size).
+   */
+  private void updateActivityContext() {
+    final Context activityContext = lifecycleProvider.getContext();
+    if (activityContext != null) {
+      this.context = activityContext;
+      this.density = activityContext.getResources().getDisplayMetrics().density;
+    }
   }
 
   private void registerToLifecycle() {
@@ -291,21 +443,46 @@ final class MapLibreMapController
     }
   }
 
+  /**
+   * Builds a fresh {@link MapView} bound to the current activity context. Caller
+   * must have already updated {@link #context} via {@link #updateActivityContext()}
+   * and must call {@link MapView#getMapAsync} AFTER the lifecycle has been bound
+   * (so {@code mapView.onCreate(savedMapViewState)} runs first via the lifecycle
+   * observer replay).
+   *
+   * <p>State preserved across recreation:
+   * <ul>
+   *   <li>{@link #lastCameraPosition} (re-applied in {@link #onMapReady}).</li>
+   *   <li>{@link #savedMapViewState} (handed to {@code mapView.onCreate}).</li>
+   *   <li>Construction-time {@link MapLibreMapOptions} (UI flags, gestures, etc.).</li>
+   *   <li>Controller fields like {@link #trackCameraPosition}, {@link #myLocationEnabled},
+   *       {@link #myLocationTrackingMode}, {@link #myLocationRenderMode}, {@link #bounds}.</li>
+   * </ul>
+   *
+   * <p>State lost across recreation (must be re-applied from Dart on
+   * {@code onStyleLoadedCallback}):
+   * <ul>
+   *   <li>Sources / layers / images added at runtime via the method channel.</li>
+   *   <li>Style switched at runtime via {@code setStyleString} (reverts to the
+   *       initial style).</li>
+   *   <li>Runtime tweaks to UI flags applied via {@code map#update} after
+   *       construction (compass, attribution, content insets, etc.).</li>
+   *   <li>In-flight gestures handled by {@link AndroidGesturesManager}.</li>
+   * </ul>
+   */
   private void recreateMapViewIfNecessary() {
     if (mapView != null) {
       return;
     }
 
-    final Context activityContext = lifecycleProvider.getContext();
-    final Context mapContext = activityContext != null ? activityContext : context;
-
-    final boolean wasPaused = userPaused;
+    final Context mapContext = (context != null) ? context : applicationContext;
 
     mapLibreMap = null;
     style = null;
     locationComponent = null;
+    mapViewCreated = false;
     mapViewStarted = false;
-    userPaused = wasPaused;
+    mapViewResumed = false;
     interactiveFeatureLayerIds.clear();
     addedFeaturesByLayer.clear();
 
@@ -315,7 +492,9 @@ final class MapLibreMapController
       androidGesturesManager = new AndroidGesturesManager(mapView.getContext(), false);
     }
     mapViewContainer.addView(mapView);
-    mapView.getMapAsync(this);
+    // NOTE: getMapAsync is intentionally NOT called here. The caller is responsible
+    // for invoking it after registerToLifecycle() so that mapView.onCreate fires
+    // first (see onActivityAttached / onActivityRebound).
   }
 
   private void moveCamera(CameraUpdate cameraUpdate) {
@@ -349,9 +528,18 @@ final class MapLibreMapController
       mapLibreMap.setLatLngBoundsForCameraTarget(bounds);
     }
 
-    // Restore camera position after map recreation (e.g. "Don't keep activities")
-    if (lastCameraPosition != null) {
-      mapLibreMap.moveCamera(CameraUpdateFactory.newCameraPosition(lastCameraPosition));
+    // Camera restoration after activity recreation.
+    // Priority order:
+    //   1. lastCameraPosition saved before the previous MapView was destroyed.
+    //   2. initial camera supplied via MapLibreMapOptions (covers the edge case
+    //      where the previous MapView was destroyed before onMapReady ever ran,
+    //      so lastCameraPosition was never populated).
+    CameraPosition restorePosition = lastCameraPosition;
+    if (restorePosition == null) {
+      restorePosition = mapLibreMapOptions.getCamera();
+    }
+    if (restorePosition != null) {
+      mapLibreMap.moveCamera(CameraUpdateFactory.newCameraPosition(restorePosition));
       lastCameraPosition = null;
     }
 
@@ -944,17 +1132,26 @@ final class MapLibreMapController
           result.success(Convert.toJson(getCameraPosition()));
           break;
         }
+      // Dart-driven pause/resume. Only flips MapView state when it's actually out
+      // of sync with the request, so we never double-call onPause/onResume against
+      // the natural Activity lifecycle (which the lifecycle observer handles).
       case "map#pause":
         userPaused = true;
-        if (mapView != null && !disposed) {
+        if (!disposed && mapView != null && mapViewResumed) {
           mapView.onPause();
+          mapViewResumed = false;
         }
         result.success(null);
         break;
       case "map#resume":
         userPaused = false;
-        if (mapView != null && !disposed) {
+        if (!disposed
+            && mapView != null
+            && !mapViewResumed
+            && boundLifecycle != null
+            && boundLifecycle.getCurrentState().isAtLeast(Lifecycle.State.RESUMED)) {
           mapView.onResume();
+          mapViewResumed = true;
         }
         result.success(null);
         break;
@@ -2286,12 +2483,9 @@ final class MapLibreMapController
       activeSnapshotter = null;
     }
     methodChannel.setMethodCallHandler(null);
-    // Properly cleanup MapView lifecycle before destroying
-    if (mapView != null && mapViewStarted) {
-      mapView.onPause();
-      mapView.onStop();
-      mapViewStarted = false;
-    }
+    // destroyMapViewIfNecessary drives the full pause -> stop -> destroy sequence,
+    // gated by the mapViewResumed/Started/Created flags so each step fires at most
+    // once. No manual onPause/onStop dance needed here.
     destroyMapViewIfNecessary();
     unregisterFromLifecycle();
 
@@ -2355,18 +2549,27 @@ final class MapLibreMapController
   }
 
   /**
-   * Destroy the MapView and cleans up listeners.
-   * It's very important to call mapViewContainer.removeView(mapView) to make sure
-   * that {@link TextureView#onDetachedFromWindowInternal()} is called which releases the
-   * underlying surface.
-   * This is required due to an FlutterEngine change that was introduce when updating from
-   * Flutter 2.10.5 to Flutter 3.10.0.
-   * This FlutterEngine change is not calling `removeView` on a PlatformView which causes the issue.
-   * <p>
-   * For more information check out:
-   * <a href="https://github.com/flutter/flutter/issues/107297">Flutter issue</a>
-   * <a href="https://github.com/flutter/engine/commit/8dc7cd1b1a33b5da561ac859cdcc49705ad1e598">Flutter Engine commit that introduced the issue</a>
-   * <a href="https://github.com/maplibre/flutter-maplibre-gl/issues/182">The reported issue in the MapLibre repo</a>
+   * Destroy the {@link MapView} and clean up listeners.
+   *
+   * <p>It's very important to call {@code mapViewContainer.removeView(mapView)} to make
+   * sure that {@link TextureView#onDetachedFromWindowInternal()} is called, which
+   * releases the underlying surface. This is required due to a FlutterEngine change
+   * introduced between Flutter 2.10.5 and 3.10.0 where {@code removeView} is no longer
+   * called on a PlatformView automatically.
+   *
+   * <p>The teardown drives the MapView lifecycle backwards using the
+   * {@code mapViewResumed/Started/Created} flags, so each step fires at most once
+   * regardless of whether dispose, lifecycle-onDestroy, or a manual detach got here
+   * first. Before destroying, MapLibre's internal state is persisted into
+   * {@link #savedMapViewState} so a subsequent {@link #recreateMapViewIfNecessary()}
+   * can restore it.
+   *
+   * <p>For more information see:
+   * <a href="https://github.com/flutter/flutter/issues/107297">Flutter issue</a>,
+   * <a href="https://github.com/flutter/engine/commit/8dc7cd1b1a33b5da561ac859cdcc49705ad1e598">the
+   * Flutter Engine commit that introduced the issue</a>, and
+   * <a href="https://github.com/maplibre/flutter-maplibre-gl/issues/182">the
+   * MapLibre tracking issue</a>.
    */
   private void destroyMapViewIfNecessary() {
     if (mapView == null) {
@@ -2378,51 +2581,84 @@ final class MapLibreMapController
     }
     stopListeningForLocationUpdates();
 
+    // Persist MapView state so it can be restored when a new MapView is created
+    // (e.g. across "Don't keep activities" or rotation).
+    if (mapViewCreated) {
+      try {
+        mapView.onSaveInstanceState(savedMapViewState);
+      } catch (Exception e) {
+        Log.w(TAG, "mapView.onSaveInstanceState failed", e);
+      }
+    }
+
     mapViewContainer.removeView(mapView);
 
-    mapView.onStop();
-    mapView.onDestroy();
+    if (mapViewResumed) {
+      mapView.onPause();
+      mapViewResumed = false;
+    }
+    if (mapViewStarted) {
+      mapView.onStop();
+      mapViewStarted = false;
+    }
+    if (mapViewCreated) {
+      mapView.onDestroy();
+      mapViewCreated = false;
+    }
 
-    mapViewStarted = false;
     mapLibreMap = null;
     style = null;
     locationComponent = null;
     mapView = null;
   }
 
+  // -- Lifecycle observer ----------------------------------------------------
+  //
+  // All five state transitions below are idempotent: each only mutates the
+  // MapView once per (MapView instance, transition) pair. This matters because
+  // Jetpack's Lifecycle.addObserver replays missed events synchronously when we
+  // re-subscribe to a fresh activity Lifecycle. Without the guards the replay
+  // would re-call mapView.onCreate / onStart / onResume on an already-initialized
+  // MapView (segnalazione #2 in PR review).
+
   @Override
   public void onCreate(@NonNull LifecycleOwner owner) {
-    if (disposed || mapView == null) {
+    if (disposed || mapView == null || mapViewCreated) {
       return;
     }
-    mapView.onCreate(null);
+    // savedMapViewState is empty on first launch and populated on subsequent
+    // recreations via destroyMapViewIfNecessary().
+    mapView.onCreate(savedMapViewState);
+    mapViewCreated = true;
   }
 
   @Override
   public void onStart(@NonNull LifecycleOwner owner) {
-    if (disposed || mapView == null) {
+    if (disposed || mapView == null || mapViewStarted) {
       return;
     }
-    if (!mapViewStarted) {
-      mapView.onStart();
-      mapViewStarted = true;
-    }
+    mapView.onStart();
+    mapViewStarted = true;
   }
 
   @Override
   public void onResume(@NonNull LifecycleOwner owner) {
-    if (disposed || mapView == null) {
+    if (disposed || mapView == null || mapViewResumed) {
       return;
     }
     if (userPaused) {
+      // Dart has explicitly paused rendering. Stay paused until resumeMap() is
+      // called, even though the host activity is in the foreground.
       return;
     }
     mapView.onResume();
+    mapViewResumed = true;
     if (myLocationEnabled) {
       startListeningForLocationUpdates();
     }
     // Force a repaint to fix invisible map when returning from background.
-    // Capture a local reference so the Runnable is safe if mapView is nulled before execution.
+    // Capture a local reference so the Runnable is safe if mapView is nulled
+    // before execution (e.g. by a concurrent dispose).
     final MapView mv = mapView;
     mv.post(new Runnable() {
       @Override
@@ -2434,21 +2670,20 @@ final class MapLibreMapController
 
   @Override
   public void onPause(@NonNull LifecycleOwner owner) {
-    if (disposed || mapView == null) {
+    if (disposed || mapView == null || !mapViewResumed) {
       return;
     }
     mapView.onPause();
+    mapViewResumed = false;
   }
 
   @Override
   public void onStop(@NonNull LifecycleOwner owner) {
-    if (disposed || mapView == null) {
+    if (disposed || mapView == null || !mapViewStarted) {
       return;
     }
-    if (mapViewStarted) {
-      mapView.onStop();
-      mapViewStarted = false;
-    }
+    mapView.onStop();
+    mapViewStarted = false;
   }
 
   @Override

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapFactory.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapFactory.java
@@ -9,12 +9,18 @@ import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.StandardMessageCodec;
 import io.flutter.plugin.platform.PlatformView;
 import io.flutter.plugin.platform.PlatformViewFactory;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
 
 public class MapLibreMapFactory extends PlatformViewFactory {
 
   private final BinaryMessenger messenger;
   private final MapLibreMapsPlugin.LifecycleProvider lifecycleProvider;
+  private final Set<MapLibreMapController> controllers =
+      Collections.newSetFromMap(new WeakHashMap<MapLibreMapController, Boolean>());
 
   public MapLibreMapFactory(
       BinaryMessenger messenger, MapLibreMapsPlugin.LifecycleProvider lifecycleProvider) {
@@ -43,6 +49,28 @@ public class MapLibreMapFactory extends PlatformViewFactory {
       builder.setStyleString(styleString);
     }
 
-    return builder.build(id, context, messenger, lifecycleProvider);
+    final MapLibreMapController controller =
+        builder.build(id, context, messenger, lifecycleProvider);
+    controllers.add(controller);
+    return controller;
+  }
+
+  void onActivityAttached() {
+    for (MapLibreMapController controller : new ArrayList<>(controllers)) {
+      controller.onActivityAttached();
+    }
+  }
+
+  void onActivityDetached() {
+    for (MapLibreMapController controller : new ArrayList<>(controllers)) {
+      controller.onActivityDetached();
+    }
+  }
+
+  /** Rebind lifecycle only — used after config changes (e.g. rotation) where map views survive. */
+  void onActivityRebound() {
+    for (MapLibreMapController controller : new ArrayList<>(controllers)) {
+      controller.onActivityRebound();
+    }
   }
 }

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapFactory.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapFactory.java
@@ -15,10 +15,31 @@ import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
 
+/**
+ * Platform-view factory for {@code plugins.flutter.io/maplibre_gl}.
+ *
+ * <p>Beyond the standard {@link PlatformViewFactory} responsibilities, this class
+ * keeps a weak registry of every {@link MapLibreMapController} it has produced so
+ * that the plugin can broadcast Flutter {@code ActivityAware} events to all live
+ * controllers when the host activity is attached, detached, or recreated.
+ *
+ * <h2>Thread-safety</h2>
+ * The registry is a {@link WeakHashMap} wrapper (not thread-safe), but all
+ * accessors — {@link #create}, the broadcast methods, and dispose-driven removals —
+ * run on the Flutter platform thread (the Android main thread), so no external
+ * synchronization is required. {@link ArrayList} snapshots are taken before
+ * iteration to defend against re-entrant mutations (e.g. a controller disposing
+ * itself in response to a lifecycle callback).
+ */
 public class MapLibreMapFactory extends PlatformViewFactory {
 
   private final BinaryMessenger messenger;
   private final MapLibreMapsPlugin.LifecycleProvider lifecycleProvider;
+  /**
+   * Weakly-referenced registry of all controllers produced by this factory. Used
+   * to fan out activity attach/detach/rebound notifications. Entries vanish
+   * automatically when the controller is garbage-collected.
+   */
   private final Set<MapLibreMapController> controllers =
       Collections.newSetFromMap(new WeakHashMap<MapLibreMapController, Boolean>());
 
@@ -55,19 +76,36 @@ public class MapLibreMapFactory extends PlatformViewFactory {
     return controller;
   }
 
+  /**
+   * Notify every live controller that the plugin has (re)attached to an activity.
+   * Triggered from {@link MapLibreMapsPlugin#onAttachedToActivity}.
+   */
   void onActivityAttached() {
     for (MapLibreMapController controller : new ArrayList<>(controllers)) {
       controller.onActivityAttached();
     }
   }
 
+  /**
+   * Notify every live controller that the plugin is being fully detached from the
+   * activity (no config change in progress). Controllers will save what state they
+   * can and tear down the native {@link io.flutter.plugin.platform.PlatformView} resources.
+   * Triggered from {@link MapLibreMapsPlugin#onDetachedFromActivity}.
+   */
   void onActivityDetached() {
     for (MapLibreMapController controller : new ArrayList<>(controllers)) {
       controller.onActivityDetached();
     }
   }
 
-  /** Rebind lifecycle only — used after config changes (e.g. rotation) where map views survive. */
+  /**
+   * Notify every live controller that the host activity has been swapped due to a
+   * configuration change (e.g. rotation). In Flutter's standard ordering the old
+   * activity has already destroyed each controller's map view by the time this
+   * fires; controllers will recreate the {@link io.flutter.plugin.platform.PlatformView}
+   * against the fresh activity context. Triggered from
+   * {@link MapLibreMapsPlugin#onReattachedToActivityForConfigChanges}.
+   */
   void onActivityRebound() {
     for (MapLibreMapController controller : new ArrayList<>(controllers)) {
       controller.onActivityRebound();

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapsPlugin.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapsPlugin.java
@@ -4,6 +4,7 @@
 
 package org.maplibre.maplibregl;
 
+import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.Lifecycle;
@@ -24,6 +25,8 @@ public class MapLibreMapsPlugin implements FlutterPlugin, ActivityAware {
 
   static FlutterAssets flutterAssets;
   private Lifecycle lifecycle;
+  private Context context;
+  private MapLibreMapFactory mapFactory;
 
   public MapLibreMapsPlugin() {
     // no-op
@@ -47,15 +50,22 @@ public class MapLibreMapsPlugin implements FlutterPlugin, ActivityAware {
         .getPlatformViewRegistry()
         .registerViewFactory(
             "plugins.flutter.io/maplibre_gl",
-            new MapLibreMapFactory(
-                binding.getBinaryMessenger(),
-                new LifecycleProvider() {
-                  @Nullable
-                  @Override
-                  public Lifecycle getLifecycle() {
-                    return lifecycle;
-                  }
-                }));
+            mapFactory =
+                new MapLibreMapFactory(
+                    binding.getBinaryMessenger(),
+                    new LifecycleProvider() {
+                      @Nullable
+                      @Override
+                      public Lifecycle getLifecycle() {
+                        return lifecycle;
+                      }
+
+                      @Nullable
+                      @Override
+                      public Context getContext() {
+                        return context;
+                      }
+                    }));
   }
 
   @Override
@@ -65,28 +75,47 @@ public class MapLibreMapsPlugin implements FlutterPlugin, ActivityAware {
 
   @Override
   public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
+    context = binding.getActivity();
     lifecycle = FlutterLifecycleAdapter.getActivityLifecycle(binding);
+    if (mapFactory != null) {
+      mapFactory.onActivityAttached();
+    }
   }
 
   @Override
   public void onDetachedFromActivityForConfigChanges() {
-    onDetachedFromActivity();
+    // Only clear references — do NOT destroy map views during config changes (e.g. rotation).
+    // The MapView survives config changes; we just need to rebind the lifecycle afterwards.
+    lifecycle = null;
+    context = null;
   }
 
   @Override
   public void onReattachedToActivityForConfigChanges(@NonNull ActivityPluginBinding binding) {
-    onAttachedToActivity(binding);
+    context = binding.getActivity();
+    lifecycle = FlutterLifecycleAdapter.getActivityLifecycle(binding);
+    // Rebind controllers to the new lifecycle without recreating map views.
+    if (mapFactory != null) {
+      mapFactory.onActivityRebound();
+    }
   }
 
   @Override
   public void onDetachedFromActivity() {
+    if (mapFactory != null) {
+      mapFactory.onActivityDetached();
+    }
     lifecycle = null;
+    context = null;
   }
 
 
   interface LifecycleProvider {
     @Nullable
     Lifecycle getLifecycle();
+
+    @Nullable
+    Context getContext();
   }
 
   /** Provides a static method for extracting lifecycle objects from Flutter plugin bindings. */

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapsPlugin.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapsPlugin.java
@@ -73,6 +73,14 @@ public class MapLibreMapsPlugin implements FlutterPlugin, ActivityAware {
     // no-op
   }
 
+  /**
+   * Called by Flutter when the plugin is attached to a host {@link android.app.Activity}.
+   * Fires on first launch and after the activity has been recreated (e.g. with
+   * "Don't keep activities"). Refreshes the lifecycle/context references exposed
+   * via {@link LifecycleProvider} and notifies live controllers so they can
+   * rebuild their {@link org.maplibre.android.maps.MapView} against the new
+   * activity context.
+   */
   @Override
   public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
     context = binding.getActivity();
@@ -82,24 +90,43 @@ public class MapLibreMapsPlugin implements FlutterPlugin, ActivityAware {
     }
   }
 
+  /**
+   * Called by Flutter when the host activity is about to be destroyed and recreated
+   * for a configuration change (e.g. rotation). We deliberately do NOT broadcast a
+   * detach to controllers here: the new activity will arrive shortly via
+   * {@link #onReattachedToActivityForConfigChanges} and the controllers will rebuild
+   * then. The old activity's natural {@code Lifecycle.onDestroy} will still tear
+   * down the {@code MapView}; persisted state (camera + MapLibre instance state)
+   * is carried across by the controller itself.
+   */
   @Override
   public void onDetachedFromActivityForConfigChanges() {
-    // Only clear references — do NOT destroy map views during config changes (e.g. rotation).
-    // The MapView survives config changes; we just need to rebind the lifecycle afterwards.
     lifecycle = null;
     context = null;
   }
 
+  /**
+   * Called by Flutter after a configuration-change-driven activity recreation has
+   * produced a new {@link android.app.Activity}. Refreshes lifecycle/context and
+   * fans out a rebound notification to controllers, which rebuild their
+   * {@code MapView} against the new activity and restore camera + MapLibre state.
+   */
   @Override
   public void onReattachedToActivityForConfigChanges(@NonNull ActivityPluginBinding binding) {
     context = binding.getActivity();
     lifecycle = FlutterLifecycleAdapter.getActivityLifecycle(binding);
-    // Rebind controllers to the new lifecycle without recreating map views.
     if (mapFactory != null) {
       mapFactory.onActivityRebound();
     }
   }
 
+  /**
+   * Called by Flutter when the plugin is being fully detached from the host
+   * activity (no config change is in progress — e.g. "Don't keep activities" has
+   * been triggered, or the activity is finishing). Notifies controllers to save
+   * what state they can and tear down their {@code MapView}. The state is held
+   * in the controllers themselves and will be restored on the next attach.
+   */
   @Override
   public void onDetachedFromActivity() {
     if (mapFactory != null) {
@@ -110,6 +137,15 @@ public class MapLibreMapsPlugin implements FlutterPlugin, ActivityAware {
   }
 
 
+  /**
+   * Late-binding accessor for the host activity {@link Lifecycle} and {@link Context}.
+   *
+   * <p>The plugin instance returned by {@link io.flutter.embedding.engine.plugins.activity.ActivityAware}
+   * callbacks can outlive any single activity, so controllers must NOT cache these
+   * values across activity recreation — they should fetch them through this provider
+   * whenever they (re)attach. Both methods return {@code null} when the plugin is
+   * not currently attached to an activity.
+   */
   interface LifecycleProvider {
     @Nullable
     Lifecycle getLifecycle();

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
@@ -321,6 +321,13 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
             // Force online mode by ensuring network requests are enabled
             // In MapLibre GL iOS, this is typically handled by the style and data sources
             result(nil)
+        case "map#pause", "map#resume":
+            // No-op on iOS. Android pauses the underlying MapView render loop here
+            // to save GPU/CPU when the widget is off-screen; on iOS the OS already
+            // halts rendering for off-screen views, so there is nothing to do.
+            // Kept as a recognised method so Dart callers don't get
+            // MissingPluginException on iOS.
+            result(nil)
         case "camera#ease":
             guard let arguments = methodCall.arguments as? [String: Any] else { 
                 result(false)

--- a/maplibre_gl/lib/src/controller.dart
+++ b/maplibre_gl/lib/src/controller.dart
@@ -1018,6 +1018,19 @@ class MapLibreMapController extends ChangeNotifier {
     return _maplibrePlatform.forceOnlineMode();
   }
 
+  /// Pauses map rendering. Call [resumeMap] to resume.
+  ///
+  /// Useful for pausing maps that are not visible (e.g. on an inactive tab)
+  /// to save GPU/CPU resources.
+  Future<void> pauseMap() async {
+    return _maplibrePlatform.pauseMap();
+  }
+
+  /// Resumes map rendering after [pauseMap].
+  Future<void> resumeMap() async {
+    return _maplibrePlatform.resumeMap();
+  }
+
   /// Eases the camera to a new position with an optional duration.
   ///
   /// The [cameraUpdate] specifies the target camera position, and [duration]

--- a/maplibre_gl/lib/src/controller.dart
+++ b/maplibre_gl/lib/src/controller.dart
@@ -1020,13 +1020,23 @@ class MapLibreMapController extends ChangeNotifier {
 
   /// Pauses map rendering. Call [resumeMap] to resume.
   ///
-  /// Useful for pausing maps that are not visible (e.g. on an inactive tab)
-  /// to save GPU/CPU resources.
+  /// Useful for pausing maps that are not visible (e.g. on an inactive tab) to
+  /// save GPU/CPU resources. The pause survives backgrounding: a map paused via
+  /// this call stays paused when the host activity returns to the foreground
+  /// until [resumeMap] is called.
+  ///
+  /// Platform behavior:
+  /// - **Android**: stops the MapView render loop.
+  /// - **iOS**: no-op. The OS already halts rendering for off-screen views.
+  /// - **Web**: no-op.
   Future<void> pauseMap() async {
     return _maplibrePlatform.pauseMap();
   }
 
   /// Resumes map rendering after [pauseMap].
+  ///
+  /// On platforms where [pauseMap] is a no-op this is also a no-op. See
+  /// [pauseMap] for platform behavior details.
   Future<void> resumeMap() async {
     return _maplibrePlatform.resumeMap();
   }

--- a/maplibre_gl/test/helpers/fake_platform.dart
+++ b/maplibre_gl/test/helpers/fake_platform.dart
@@ -123,6 +123,12 @@ class FakeMapLibrePlatform extends MapLibrePlatform {
   Future<void> forceOnlineMode() async {}
 
   @override
+  Future<void> pauseMap() async {}
+
+  @override
+  Future<void> resumeMap() async {}
+
+  @override
   Future<bool> easeCamera(
     CameraUpdate cameraUpdate, {
     Duration? duration,

--- a/maplibre_gl_platform_interface/CHANGELOG.md
+++ b/maplibre_gl_platform_interface/CHANGELOG.md
@@ -1,3 +1,10 @@
+See top-level [CHANGELOG.md](../CHANGELOG.md) for full details.
+
+## Unreleased
+
+### Added
+* `MapLibrePlatform.pauseMap()` and `MapLibrePlatform.resumeMap()` abstract methods, with corresponding `map#pause` / `map#resume` method-channel handlers in `MapLibreMethodChannel`. Subclasses must implement the new methods (a no-op suffices for platforms without an active render loop) (#805).
+
 ## [0.26.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.25.0...v0.26.0)
 
 See top-level [CHANGELOG.md](../CHANGELOG.md) for full details.

--- a/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
+++ b/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
@@ -127,6 +127,12 @@ abstract class MapLibrePlatform {
   /// Forces the map to use online mode (disables offline mode).
   Future<void> forceOnlineMode();
 
+  /// Pauses map rendering. Call [resumeMap] to resume.
+  Future<void> pauseMap();
+
+  /// Resumes map rendering after [pauseMap].
+  Future<void> resumeMap();
+
   /// Animates the camera to a new position with a specified duration and interpolation.
   ///
   /// The [cameraUpdate] specifies the target camera position.

--- a/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
+++ b/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
@@ -285,6 +285,16 @@ class MapLibreMethodChannel extends MapLibrePlatform {
   }
 
   @override
+  Future<void> pauseMap() async {
+    await _channel.invokeMethod('map#pause');
+  }
+
+  @override
+  Future<void> resumeMap() async {
+    await _channel.invokeMethod('map#resume');
+  }
+
+  @override
   Future<bool> easeCamera(
     CameraUpdate cameraUpdate, {
     Duration? duration,

--- a/maplibre_gl_web/CHANGELOG.md
+++ b/maplibre_gl_web/CHANGELOG.md
@@ -1,5 +1,10 @@
 See top-level [CHANGELOG.md](../CHANGELOG.md) for full details.
 
+## Unreleased
+
+### Added
+* `pauseMap` / `resumeMap` no-op implementations to satisfy the new platform-interface contract. MapLibre GL JS handles visibility-driven pausing internally on the web, so no separate render-loop control is needed (#805).
+
 ## [0.26.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.25.0...v0.26.0)
 
 ### Breaking

--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -355,6 +355,16 @@ class MapLibreMapController extends MapLibrePlatform
   }
 
   @override
+  Future<void> pauseMap() async {
+    // No-op on web.
+  }
+
+  @override
+  Future<void> resumeMap() async {
+    // No-op on web.
+  }
+
+  @override
   Future<bool> easeCamera(
     CameraUpdate cameraUpdate, {
     Duration? duration,


### PR DESCRIPTION
When Android's "Don't keep activities" option is enabled the Activity is fully destroyed on background and recreated on resume. The MapView held references to the dead Activity context and lifecycle, leaving the map permanently blank.

- Track controllers via WeakHashMap in MapLibreMapFactory and broadcast activity attach/detach/rebound events.
- On full detach save camera position, destroy the MapView, and recreate it with the fresh Activity context on re-attach.
- On config changes (rotation) only rebind the lifecycle; skip the expensive destroy/recreate unless the old lifecycle's onDestroy already tore the map down.
- Guard onDestroy against stale lifecycle callbacks so a late-arriving old-activity onDestroy cannot kill a map that already rebound.
- Return MAP_NOT_READY error for method-channel calls that arrive while the map is being recreated instead of crashing with an NPE.
- Clear stale interactiveFeatureLayerIds / addedFeaturesByLayer on recreation, fix posted Runnable null-safety in onResume, and register ComponentCallbacks on applicationContext.