### PR TITLE
fix(android): null-check mapView inside onResume repaint runnable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## Unreleased
+
+### Fixed
+* **Android**: Fix `NullPointerException` in the repaint runnable posted by `MapLibreMapController.onResume`. The runnable reads the controller's `mapView` field after the main `Looper` drains, so when `dispose()` runs first (e.g. a map hosted in a `Dialog` or `BottomSheet` that is dismissed mid-resume) the field is `null` and `mapView.invalidate()` throws. The runnable now re-checks `disposed`/`mapView`, mirroring the guard at the top of `onResume`.
+
 ## [0.26.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.25.0...v0.26.0)
 
 #### Version 0.26.0 marks a milestone for `flutter-maplibre-gl`

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
@@ -2288,11 +2288,17 @@ final class MapLibreMapController
     if (myLocationEnabled) {
       startListeningForLocationUpdates();
     }
-    // Force a repaint to fix invisible map when returning from background
-    // Use standard Android view invalidation to trigger a repaint
+    // Force a repaint to fix invisible map when returning from background.
+    // The runnable is dispatched after the message loop drains, by which time
+    // dispose() may have nulled mapView (e.g. a map hosted in a Dialog or
+    // BottomSheet that is dismissed mid-resume). Re-check disposed/mapView
+    // inside the runnable to mirror the guard at the top of onResume.
     mapView.post(new Runnable() {
       @Override
       public void run() {
+        if (disposed || mapView == null) {
+          return;
+        }
         mapView.invalidate();
       }
     });


### PR DESCRIPTION
## Summary

- `MapLibreMapController.onResume` posts a `Runnable` that calls `mapView.invalidate()` to force a repaint after returning from background
- The runnable reads the controller's `mapView` field after the main `Looper` drains — if `dispose()` runs before the runnable executes (e.g. a map hosted in a `Dialog` or `BottomSheet` that is dismissed mid-resume), `mapView` is `null` and `mapView.invalidate()` throws `NullPointerException`, crashing the host activity
- Fix: re-check `disposed || mapView == null` at the top of the runnable — mirrors the identical guard already at the top of `onResume` itself, and the pattern used by every other lifecycle callback (`onPause`, `onStop`, `onDestroy`)

## Reproduction

1. Host a `MapLibreMap` inside a `Dialog` or `BottomSheet`
2. Send the app to background, then return immediately
3. Dismiss the dialog/sheet before the repaint runnable drains from the `Looper`
4. `NullPointerException` in `MapLibreMapController$1.run` crashes the activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)