### PR TITLE
docs(web): updated `maplibre-gl` JavaScript and CSS version to `5.24.0` in `README.md`

### DIFF
--- a/maplibre_gl/README.md
+++ b/maplibre_gl/README.md
@@ -164,8 +164,8 @@ Request permissions at runtime yourself (e.g. via the [`location`](https://pub.d
 Include the following JavaScript and CSS files in the `<head>` of your `web/index.html` file:
 
 ```html
-<script src="https://unpkg.com/maplibre-gl@^4.3/dist/maplibre-gl.js"></script>
-<link href="https://unpkg.com/maplibre-gl@^4.3/dist/maplibre-gl.css" rel="stylesheet" />
+<script src='https://unpkg.com/maplibre-gl@^5.24.0/dist/maplibre-gl.js'></script>
+<link href='https://unpkg.com/maplibre-gl@^5.24.0/dist/maplibre-gl.css' rel='stylesheet'/>
 ```
 
 ---


### PR DESCRIPTION
In `README.md`  web section the JavaScript and CSS `maplibre-gl` version  is `4.3.0`. 

Configuring web project using  old version `4.3.0` causes `NoSuchMethodError: tried to call a non-function, such as null: 'this.jsObject.unsubscribe'` on `MapLibreMap` dispose as reported in #808.

Upgrading to `5.24.0` exception isn't raised.
