### PR TITLE
Release 0.26.1

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,4 +17,4 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@v6
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## Unreleased
+## [0.26.1](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.26.0...v0.26.1)
+
+> **Note:** Several users reported crashes on a range of Android devices after upgrading to 0.26.0, particularly on older / less recent hardware. These issues are addressed in 0.26.1 (see the Android fixes below).
 
 ### Fixed
-* **Android**: Fix `NullPointerException` in the repaint runnable posted by `MapLibreMapController.onResume`. The runnable reads the controller's `mapView` field after the main `Looper` drains, so when `dispose()` runs first (e.g. a map hosted in a `Dialog` or `BottomSheet` that is dismissed mid-resume) the field is `null` and `mapView.invalidate()` throws. The runnable now re-checks `disposed`/`mapView`, mirroring the guard at the top of `onResume`.
+* **Android**: Hybrid composition now correctly enables `textureMode` when necessary, preventing crashes and rendering and issues with platform views (#816).
+* **Android**: Null-check `mapView` inside the `onResume` repaint runnable to avoid `NullPointerException` when the map is disposed (e.g. dialogs/bottom sheets) before the posted runnable drains (#809).
+* De-register the annotation drag callback on `AnnotationManager.dispose()` to prevent jumpy drags and `_idToAnnotation.containsKey` crashes after style reloads on Android and iOS (#806).
+
+### Changed
+* **Android**: MapLibre Android SDK upgraded from 13.0.2 to 13.1.0 (#811).
+* **iOS**: MapLibre iOS upgraded from 6.25.1 to 6.26.0.
+
+### Docs
+* **Web**: Updated `maplibre-gl` JavaScript and CSS version to `5.24.0` in `README.md` to avoid `NoSuchMethodError` on `MapLibreMap` dispose with the previously referenced 4.3.0 version (#814).
 
 ## [0.26.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.25.0...v0.26.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## Unreleased
+
+### Fixed
+* **Android**: Fix `NullPointerException` in the repaint runnable posted by `MapLibreMapController.onResume`. The runnable reads the controller's `mapView` field after the main `Looper` drains, so when `dispose()` runs first (e.g. a map hosted in a `Dialog` or `BottomSheet` that is dismissed mid-resume) the field is `null` and `mapView.invalidate()` throws. The runnable now re-checks `disposed`/`mapView`, mirroring the guard at the top of `onResume`.
+
 ## [0.26.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.25.0...v0.26.0)
 
 #### Version 0.26.0 marks a milestone for `flutter-maplibre-gl`

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -1,3 +1,19 @@
+## [0.26.1](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.26.0...v0.26.1)
+
+> **Note:** Several users reported crashes on a range of Android devices after upgrading to 0.26.0, particularly on older / less recent hardware. These issues are addressed in 0.26.1 (see the Android fixes below).
+
+### Fixed
+* **Android**: Hybrid composition now correctly enables `textureMode` when necessary, preventing crashes and rendering and issues with platform views (#816).
+* **Android**: Null-check `mapView` inside the `onResume` repaint runnable to avoid `NullPointerException` when the map is disposed (e.g. dialogs/bottom sheets) before the posted runnable drains (#809).
+* De-register the annotation drag callback on `AnnotationManager.dispose()` to prevent jumpy drags and `_idToAnnotation.containsKey` crashes after style reloads on Android and iOS (#806).
+
+### Changed
+* **Android**: MapLibre Android SDK upgraded from 13.0.2 to 13.1.0 (#811).
+* **iOS**: MapLibre iOS upgraded from 6.25.1 to 6.26.0.
+
+### Docs
+* **Web**: Updated `maplibre-gl` JavaScript and CSS version to `5.24.0` in `README.md` to avoid `NoSuchMethodError` on `MapLibreMap` dispose with the previously referenced 4.3.0 version (#814).
+
 ## [0.26.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.25.0...v0.26.0)
 
 **Version 0.26.0 is a milestone release for flutter-maplibre-gl.** \

--- a/maplibre_gl/android/build.gradle
+++ b/maplibre_gl/android/build.gradle
@@ -57,7 +57,7 @@ android {
     dependencies {
         // Using OpenGL instead of new Vulkan-based renderer for now, as it is more stable and has better performance on older devices.
         // If we want to use the Vulkan-based renderer in the future, we can switch to the regular SDK dependency below and remove the exclusion above.
-        implementation 'org.maplibre.gl:android-sdk-opengl:13.0.2'
+        implementation 'org.maplibre.gl:android-sdk-opengl:13.1.0'
         implementation 'org.maplibre.gl:android-plugin-annotation-v9:3.0.2'
         implementation 'org.maplibre.gl:android-plugin-offline-v9:3.0.2'
         implementation 'com.squareup.okhttp3:okhttp:5.3.2'

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/Convert.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/Convert.java
@@ -317,6 +317,10 @@ static LocationEngineRequest toLocationEngineRequest(Object o) {
     if (foregroundLoadColor != null) {
       sink.setForegroundLoadColor(toInt(foregroundLoadColor));
     }
+    final Object useHybridComposition = data.get("useHybridComposition");
+    if (useHybridComposition != null) {
+      sink.setUseHybridComposition(toBoolean(useHybridComposition));
+    }
     final Object translucentTextureSurface = data.get("translucentTextureSurface");
     if (translucentTextureSurface != null) {
       sink.setTranslucentTextureSurface(toBoolean(translucentTextureSurface));

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapBuilder.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapBuilder.java
@@ -26,6 +26,8 @@ class MapLibreMapBuilder implements MapLibreMapOptionsSink {
   private String styleString = "";
   private LatLngBounds bounds = null;
   private LocationEngineRequest locationEngineRequest = null;
+  private boolean translucentRequested = false;
+  private boolean hybridCompositionActive = false;
 
   MapLibreMapController build(
       int id,
@@ -261,9 +263,16 @@ class MapLibreMapBuilder implements MapLibreMapOptionsSink {
 
   @Override
   public void setTranslucentTextureSurface(boolean translucentTextureSurface) {
+    this.translucentRequested = translucentTextureSurface;
     options.translucentTextureSurface(translucentTextureSurface);
-    // TextureMode is required for translucent surfaces, but causes frame sync issues
-    // Only enable it when transparency is actually needed
-    options.textureMode(translucentTextureSurface);
+    // textureMode must be on if EITHER a translucent surface is required OR Flutter is
+    // using Hybrid Composition (TLHC). Both are correctness requirements, not knobs.
+    options.textureMode(translucentRequested || hybridCompositionActive);
+  }
+
+  @Override
+  public void setUseHybridComposition(boolean useHybridComposition) {
+    this.hybridCompositionActive = useHybridComposition;
+    options.textureMode(translucentRequested || hybridCompositionActive);
   }
 }

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
@@ -2557,6 +2557,13 @@ final class MapLibreMapController
   }
 
   @Override
+  public void setUseHybridComposition(boolean useHybridComposition) {
+    // useHybridComposition selects the Platform-View backing (TextureView vs SurfaceView)
+    // and is only meaningful before the map's native view has been constructed.
+    // At runtime the chosen surface is fixed, so this is a no-op.
+  }
+
+  @Override
   public void setFeatureTapsTriggersMapClick(boolean triggers) {
     this.featureTapsTriggersMapClick = triggers;
   }

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
@@ -2288,11 +2288,17 @@ final class MapLibreMapController
     if (myLocationEnabled) {
       startListeningForLocationUpdates();
     }
-    // Force a repaint to fix invisible map when returning from background
-    // Use standard Android view invalidation to trigger a repaint
+    // Force a repaint to fix invisible map when returning from background.
+    // The runnable is dispatched after the message loop drains, by which time
+    // dispose() may have nulled mapView (e.g. a map hosted in a Dialog or
+    // BottomSheet that is dismissed mid-resume). Re-check disposed/mapView
+    // inside the runnable to mirror the guard at the top of onResume.
     mapView.post(new Runnable() {
       @Override
       public void run() {
+        if (disposed || mapView == null) {
+          return;
+        }
         mapView.invalidate();
       }
     });

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapOptionsSink.kt
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapOptionsSink.kt
@@ -55,4 +55,6 @@ internal interface MapLibreMapOptionsSink {
     fun setTranslucentTextureSurface(translucentTextureSurface: Boolean)
 
     fun setFeatureTapsTriggersMapClick(triggers: Boolean)
+
+    fun setUseHybridComposition(useHybridComposition: Boolean)
 }

--- a/maplibre_gl/ios/maplibre_gl.podspec
+++ b/maplibre_gl/ios/maplibre_gl.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'maplibre_gl'
-  s.version          = '0.26.0'
+  s.version          = '0.26.1'
   s.summary          = 'MapLibre GL Flutter plugin'
   s.description      = <<-DESC
 MapLibre GL Flutter plugin.
@@ -16,7 +16,7 @@ MapLibre GL Flutter plugin.
   s.dependency 'Flutter'
   # When updating the dependency version,
   # make sure to also update the version in Package.swift.
-  s.dependency 'MapLibre', '6.25.1'
+  s.dependency 'MapLibre', '6.26.0'
   s.swift_version = '5.0'
   s.ios.deployment_target = '13.0'
 end

--- a/maplibre_gl/lib/src/annotation_manager.dart
+++ b/maplibre_gl/lib/src/annotation_manager.dart
@@ -49,6 +49,15 @@ abstract class AnnotationManager<T extends Annotation> {
   /// Returns the annotation with the given [id], or null if not found.
   T? byId(String id) => _idToAnnotation[id];
 
+  /// Stored drag callback reference so we can reliably de-register it.
+  ///
+  /// This must be the *same* function instance used with
+  /// `controller.onFeatureDrag.add(...)`, otherwise `remove(...)` may fail
+  /// (method tear-offs can create new function objects).
+  ///
+  /// Prevents duplicate/stale drag handlers after style reloads.
+  late final OnFeatureDragCallback _dragCb = _onDrag;
+
   /// Current set of managed annotations.
   Set<T> get annotations => _idToAnnotation.values.toSet();
 
@@ -84,7 +93,8 @@ abstract class AnnotationManager<T extends Annotation> {
         );
       }
 
-      controller.onFeatureDrag.add(_onDrag);
+      controller.onFeatureDrag.remove(_dragCb); // safe even if not present
+      controller.onFeatureDrag.add(_dragCb);
 
       // Mark as initialized
       _isInitialized = true;
@@ -180,6 +190,7 @@ abstract class AnnotationManager<T extends Annotation> {
   Future<void> dispose() async {
     if (controller.isDisposed) return;
     _idToAnnotation.clear();
+    controller.onFeatureDrag.remove(_dragCb);
 
     await _setAll();
     for (var i = 0; i < allLayerProperties.length; i++) {

--- a/maplibre_gl/pubspec.yaml
+++ b/maplibre_gl/pubspec.yaml
@@ -1,6 +1,6 @@
 name: maplibre_gl
 description: A Flutter plugin for integrating MapLibre Maps inside a Flutter application on Android, iOS and web platforms.
-version: 0.26.0
+version: 0.26.1
 repository: https://github.com/maplibre/flutter-maplibre-gl
 issue_tracker: https://github.com/maplibre/flutter-maplibre-gl/issues
 resolution: workspace
@@ -12,8 +12,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  maplibre_gl_platform_interface: ^0.26.0
-  maplibre_gl_web: ^0.26.0
+  maplibre_gl_platform_interface: ^0.26.1
+  maplibre_gl_web: ^0.26.1
 
 dev_dependencies:
   flutter_test:

--- a/maplibre_gl/test/annotation_manager_test.dart
+++ b/maplibre_gl/test/annotation_manager_test.dart
@@ -318,6 +318,97 @@ void main() {
     });
   });
 
+  group('AnnotationManager drag callback lifecycle', () {
+    test('initialize registers one drag callback per manager', () {
+      // setUp() initializes 4 managers (fill, line, circle, symbol).
+      expect(controller.onFeatureDrag.length, 4);
+    });
+
+    test('repeated initialize is idempotent', () async {
+      final before = controller.onFeatureDrag.length;
+      await controller.symbolManager!.initialize();
+      await controller.symbolManager!.initialize();
+      expect(controller.onFeatureDrag.length, before);
+    });
+
+    test('dispose removes the manager drag callback', () async {
+      final before = controller.onFeatureDrag.length;
+      await controller.symbolManager!.dispose();
+      expect(controller.onFeatureDrag.length, before - 1);
+
+      await controller.lineManager!.dispose();
+      expect(controller.onFeatureDrag.length, before - 2);
+    });
+
+    test('dispose preserves other managers and user-added callbacks', () async {
+      void userCallback(_, _, _, _, _, _, _) {}
+      controller.onFeatureDrag.add(userCallback);
+
+      await controller.symbolManager!.dispose();
+
+      // Symbol manager removed, but the other 3 + user callback remain.
+      expect(controller.onFeatureDrag.length, 4);
+      expect(controller.onFeatureDrag, contains(userCallback));
+    });
+
+    test('style-reload cycle does not leak stale drag callbacks', () async {
+      // Reproduces the scenario from PR #806: on every style reload the
+      // controller disposes existing managers and creates new ones. Without
+      // the fix, each reload would leave the previous _onDrag registered,
+      // accumulating duplicates.
+      final initial = controller.onFeatureDrag.length;
+
+      for (var i = 0; i < 3; i++) {
+        platform.onMapStyleLoadedPlatform.call(null);
+        // The handler is async fire-and-forget through ArgumentCallbacks;
+        // drain the microtask queue until dispose+initialize complete.
+        await pumpEventQueue();
+      }
+
+      expect(controller.onFeatureDrag.length, initial);
+    });
+
+    test(
+      'drag event after style reload does not target a disposed manager',
+      () async {
+        final oldSymbol = await controller.addSymbol(
+          const SymbolOptions(geometry: LatLng(0, 0), draggable: true),
+        );
+
+        // Trigger the real style-reload code path on the controller.
+        platform.onMapStyleLoadedPlatform.call(null);
+        await pumpEventQueue();
+
+        final newSymbol = await controller.addSymbol(
+          const SymbolOptions(geometry: LatLng(10, 20), draggable: true),
+        );
+
+        final dragged = <String>[];
+        controller.onFeatureDrag.add(
+          (point, origin, current, delta, id, annotation, eventType) {
+            dragged.add(id);
+          },
+        );
+
+        platform.onFeatureDraggedPlatform.call({
+          'id': newSymbol.id,
+          'eventType': DragEventType.drag.name,
+          'point': const Point(0.0, 0.0),
+          'origin': const LatLng(10, 20),
+          'current': const LatLng(10.001, 20.001),
+          'delta': const LatLng(0.001, 0.001),
+        });
+
+        // Only the new manager (and our observer) should have been notified.
+        // With the bug, the old manager's stale _onDrag would also fire.
+        expect(dragged, [newSymbol.id]);
+        expect(controller.symbolManager!.byId(newSymbol.id), isNotNull);
+        // Old symbol's id is unrelated to anything live now.
+        expect(controller.symbolManager!.byId(oldSymbol.id), isNull);
+      },
+    );
+  });
+
   group('AnnotationManager GeoJSON output', () {
     test('setGeoJsonSource is called with FeatureCollection on add', () async {
       platform.reset();

--- a/maplibre_gl_example/ios/Podfile.lock
+++ b/maplibre_gl_example/ios/Podfile.lock
@@ -4,10 +4,10 @@ PODS:
   - Flutter (1.0.0)
   - location (0.0.1):
     - Flutter
-  - MapLibre (6.25.1)
-  - maplibre_gl (0.26.0):
+  - MapLibre (6.26.0)
+  - maplibre_gl (0.26.1):
     - Flutter
-    - MapLibre (= 6.25.1)
+    - MapLibre (= 6.26.0)
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -39,8 +39,8 @@ SPEC CHECKSUMS:
   device_info_plus: bf2e3232933866d73fe290f2942f2156cdd10342
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   location: d5cf8598915965547c3f36761ae9cc4f4e87d22e
-  MapLibre: 117b8f7f7956137697fc72f7485261f65d770091
-  maplibre_gl: 44719322523b9cc0b6888afdca7fc2ab8447087f
+  MapLibre: b7ef5623a1a61468c4266a048e494181c10173ad
+  maplibre_gl: 35711b5c0c7170aea73224bf7e8f48ff15510621
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
 
 PODFILE CHECKSUM: a57f30d18f102dd3ce366b1d62a55ecbef2158e5

--- a/maplibre_gl_example/pubspec.yaml
+++ b/maplibre_gl_example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_gl_example
 description: Demonstrates how to use the maplibre_gl plugin.
 publish_to: 'none'
-version: 0.26.0
+version: 0.26.1
 repository: https://github.com/maplibre/flutter-maplibre-gl
 issue_tracker: https://github.com/maplibre/flutter-maplibre-gl/issues
 resolution: workspace

--- a/maplibre_gl_platform_interface/CHANGELOG.md
+++ b/maplibre_gl_platform_interface/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.26.1](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.26.0...v0.26.1)
+
+See top-level [CHANGELOG.md](../CHANGELOG.md) for full details.
+
+### Fixed
+* **Android**: Forward `textureMode` through the method channel so hybrid composition can enable it when necessary (#816).
+
 ## [0.26.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.25.0...v0.26.0)
 
 See top-level [CHANGELOG.md](../CHANGELOG.md) for full details.

--- a/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
+++ b/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
@@ -136,6 +136,7 @@ class MapLibreMethodChannel extends MapLibrePlatform {
     Set<Factory<OneSequenceGestureRecognizer>>? gestureRecognizers,
   ) {
     if (defaultTargetPlatform == TargetPlatform.android) {
+      creationParams['options']?['useHybridComposition'] = useHybridComposition;
       if (useHybridComposition) {
         return PlatformViewLink(
           viewType: 'plugins.flutter.io/maplibre_gl',

--- a/maplibre_gl_platform_interface/pubspec.yaml
+++ b/maplibre_gl_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: maplibre_gl_platform_interface
 description: A common platform interface for the maplibre_gl plugin. This package is only intended to be used by the maplibre_gl package.
-version: 0.26.0
+version: 0.26.1
 repository: https://github.com/maplibre/flutter-maplibre-gl
 issue_tracker: https://github.com/maplibre/flutter-maplibre-gl/issues
 resolution: workspace

--- a/maplibre_gl_web/CHANGELOG.md
+++ b/maplibre_gl_web/CHANGELOG.md
@@ -1,5 +1,9 @@
 See top-level [CHANGELOG.md](../CHANGELOG.md) for full details.
 
+## [0.26.1](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.26.0...v0.26.1)
+
+No web-specific changes; version aligned with the `maplibre_gl` 0.26.1 release. See top-level [CHANGELOG.md](../CHANGELOG.md) for full details.
+
 ## [0.26.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.25.0...v0.26.0)
 
 ### Breaking

--- a/maplibre_gl_web/pubspec.yaml
+++ b/maplibre_gl_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: maplibre_gl_web
 description: Web platform implementation of maplibre_gl. This package is only intended to be used by the maplibre_gl package.
-version: 0.26.0
+version: 0.26.1
 repository: https://github.com/maplibre/flutter-maplibre-gl
 issue_tracker: https://github.com/maplibre/flutter-maplibre-gl/issues
 resolution: workspace
@@ -22,7 +22,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   image: ^4.8.0
-  maplibre_gl_platform_interface: ^0.26.0
+  maplibre_gl_platform_interface: ^0.26.1
   meta: ^1.17.0
   web: ^1.1.1
 

--- a/scripts/pubspec.yaml
+++ b/scripts/pubspec.yaml
@@ -3,7 +3,7 @@ description: code generation for flutter-maplibre-gl
 publish_to: 'none'
 resolution: workspace
 
-version: 0.26.0
+version: 0.26.1
 
 environment:
   sdk: ">=3.7.0 <4.0.0"


### PR DESCRIPTION
> **Note:** Several users reported crashes on a range of Android devices after upgrading to 0.26.0, particularly on older / less recent hardware. These issues are addressed in 0.26.1 (see the Android fixes below).

### Fixed
* **Android**: Hybrid composition now correctly enables `textureMode` when necessary, preventing crashes and rendering and issues with platform views (#816).
* **Android**: Null-check `mapView` inside the `onResume` repaint runnable to avoid `NullPointerException` when the map is disposed (e.g. dialogs/bottom sheets) before the posted runnable drains (#809).
* De-register the annotation drag callback on `AnnotationManager.dispose()` to prevent jumpy drags and `_idToAnnotation.containsKey` crashes after style reloads on Android and iOS (#806).

### Changed
* **Android**: MapLibre Android SDK upgraded from 13.0.2 to 13.1.0 (#811).
* **iOS**: MapLibre iOS upgraded from 6.25.1 to 6.26.0.

### Docs
* **Web**: Updated `maplibre-gl` JavaScript and CSS version to `5.24.0` in `README.md` to avoid `NoSuchMethodError` on `MapLibreMap` dispose with the previously referenced 4.3.0 version (#814).